### PR TITLE
Transform namespace extended with new functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # IterTools Typescript Change Log
 
+## v1.12.0 - 2023-03-21
+
+### New Features
+* transform
+  * `toMap()`
+  * `toSet()`
+* Stream
+  * `toMap()`
+  * `toSet()`
+* types
+  * `RecordKey`
+
+### Improvements
+* `transform.toIterable()` now can also accept records as input.
+
 ## v1.11.0 - 2023-03-20
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -1382,12 +1382,14 @@ const falseResult = summary.sameCount(batmanMovies, matrixMovies);
 
 ## Transform
 ### To Iterable
-Returns `Iterable` instance of given collection or iterator.
+Returns `Iterable` instance of given collection, record or iterator.
 
 Throws `InvalidArgumentError` if given data is not a collection or an iterator.
 
 ```
-function toIterable<T>(collection: Iterable<T>|Iterator<T>): Iterable<T>
+function toIterable<T>(
+  collection: Iterable<T>|Iterator<T>|Record<string|number|symbol, unknown>
+): Iterable<T>
 ```
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Quick Reference
 | [`toArray`](#To-Array)       | Transforms collection to array    | `transform.toArray(data)`    |
 | [`toIterable`](#To-Iterable) | Transforms collection to iterable | `transform.toIterable(data)` |
 | [`toIterator`](#To-Iterator) | Transforms collection to iterator | `transform.toIterator(data)` |
+| [`toMap`](#To-Map)           | Transforms collection to map      | `transform.toMap(pairs)`     |
+| [`toSet`](#To-Set)           | Transforms collection to set      | `transform.toSet(data)`      |
 
 ### Stream Iteration Tools
 #### Stream Sources
@@ -185,9 +187,11 @@ Quick Reference
 
 #### Stream Terminal Operations
 ##### Transformation Terminal Operations
-| Terminal Operation       | Description                      | Code Snippet       |
-|--------------------------|----------------------------------|--------------------|
-| [`toArray`](#To-Array-1) | Returns array of stream elements | `stream.toArray()` |
+| Terminal Operation       | Description                                      | Code Snippet       |
+|--------------------------|--------------------------------------------------|--------------------|
+| [`toArray`](#To-Array-1) | Returns array of stream elements                 | `stream.toArray()` |
+| [`toMap`](#To-Map-1)     | Returns map of stream elements (key-value pairs) | `stream.toMap()`   |
+| [`toSet`](#To-Set-1)     | Returns set of stream elements                   | `stream.toSet()`   |
 
 ##### Reduction Terminal Operations
 | Terminal Operation                       | Description                                     | Code Snippet                            |
@@ -1381,6 +1385,24 @@ const falseResult = summary.sameCount(batmanMovies, matrixMovies);
 ```
 
 ## Transform
+### To Array
+Returns `Array` instance of given collection or iterator.
+
+```
+function toArray<T>(
+  collection: Iterable<T>|Iterator<T>
+): Array<T>
+```
+
+```typescript
+import { transform } from "itertools-ts";
+
+const iterator = transform.toIterator([1, 2, 3, 4, 5]);
+
+const result = transform.toArray(iterator);
+// [1, 2, 3, 4, 5]
+```
+
 ### To Iterable
 Returns `Iterable` instance of given collection, record or iterator.
 
@@ -1401,22 +1423,6 @@ const result = transform.toIterable(input);
 // [1, 2, 3, 4, 5]
 ```
 
-### To Array
-Returns `Array` instance of given collection or iterator.
-
-```
-function toArray<T>(collection: Iterable<T>|Iterator<T>): Array<T>
-```
-
-```typescript
-import { transform } from "itertools-ts";
-
-const iterator = transform.toIterator([1, 2, 3, 4, 5]);
-
-const result = transform.toArray(iterator);
-// [1, 2, 3, 4, 5]
-```
-
 ### To Iterator
 Returns `Iterator` instance of given collection or iterator.
 
@@ -1434,6 +1440,42 @@ const input = [1, 2, 3, 4, 5];
 const result = transform.toIterator(input);
 console.log(result.next !== undefined);
 // true
+```
+
+### To Map
+Converts given iterable of key-value pairs to Map.
+
+```
+function toMap<TKey, TValue>(
+  pairs: Iterable<[TKey, TValue]> | Iterator<[TKey, TValue]> | Record<string|number|symbol, unknown>
+): Map<TKey, TValue>
+```
+
+```typescript
+import { transform } from "itertools-ts";
+
+const input = [['a', 1], ['b', 2], ['c', 3]];
+
+const result = transform.toMap(input);
+// Map([['a', 1], ['b', 2], ['c', 3]])
+```
+
+### To Set
+Converts given iterable to Set.
+
+```
+function toSet<T>(
+  collection: Iterable<T> | Iterator<T>
+): Set<T>
+```
+
+```typescript
+import { transform } from "itertools-ts";
+
+const input = [1, 1, 2, 2, 3, 3];
+
+const result = transform.toSet(input);
+// Set([1, 2, 3])
 ```
 
 ## Stream
@@ -2050,6 +2092,39 @@ const result = Stream.of([1, 2, 3, 4, 5])
   .map((x) => x**2)
   .toArray();
 // [1, 4, 9, 16, 25]
+```
+
+##### To Map
+Converts stream to Map.
+
+```
+stream.toMap(): Map<unknown, unknown>
+```
+
+Stream collection must contain only key-value pairs as elements.
+
+```typescript
+import { Stream } from "itertools-ts";
+
+const result = Stream.of([1, 2, 3])
+  .enumerate()
+  .toMap();
+// Map([[0, 1], [1, 2], [2, 3]])
+```
+
+##### To Set
+Converts stream to Set.
+
+```
+stream.toSet(): Set<unknown>
+```
+
+```typescript
+import { Stream } from "itertools-ts";
+
+const result = Stream.of([1, 1, 2, 2, 3, 3])
+  .toMap();
+// Set([1, 2, 3])
 ```
 
 #### Reduce Terminal Operations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itertools-ts",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Extended itertools port for TypeScript. Provides a huge set of functions for working with iterable collections",
   "license": "MIT",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,11 @@ import {
   sameCount,
 } from "./summary";
 
-import { toArray, toIterable, toIterator } from "./transform";
+import { toArray, toIterable, toIterator, toMap, toSet } from "./transform";
 
 import { InvalidArgumentError, LengthError } from "./exceptions";
 
-import { FlatMapper, Pair, Comparable } from "./types";
+import { FlatMapper, Pair, Comparable, RecordKey } from "./types";
 
 export const single = {
   chunkwise,
@@ -134,10 +134,12 @@ export const transform = {
   toArray,
   toIterable,
   toIterator,
+  toMap,
+  toSet,
 };
 
 export { Stream };
 
-export type { FlatMapper, Pair, Comparable };
+export type { FlatMapper, Pair, Comparable, RecordKey };
 
 export { InvalidArgumentError, LengthError };

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import { toArray, toIterable } from "./transform";
+import { toArray, toIterable, toMap, toSet } from "./transform";
 import {
   chunkwise,
   chunkwiseOverlap,
@@ -689,12 +689,32 @@ export class Stream {
   }
 
   /**
-   * Converts iterable source to array.
+   * Converts stream to Array.
    *
    * @see transform.toArray
    */
   toArray(): Array<unknown> {
     return toArray(this);
+  }
+
+  /**
+   * Converts stream to Map.
+   *
+   * Stream collection must contain only key-value pairs as elements.
+   *
+   * @see transform.toMap
+   */
+  toMap(): Map<unknown, unknown> {
+    return toMap(this as Iterable<[unknown, unknown]>);
+  }
+
+  /**
+   * Converts stream to Set.
+   *
+   * @see transform.toSet
+   */
+  toSet(): Set<unknown> {
+    return toSet(this);
   }
 
   /**

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,6 @@
 import { InvalidArgumentError } from "./exceptions";
 import { isIterable, isIterator } from "./summary";
-import { Pair, RecordKey } from './types';
+import { RecordKey } from "./types";
 
 /**
  * Converts collection or record to Iterable instance.
@@ -24,11 +24,14 @@ export function toIterable<T>(
     };
   }
 
-  if (typeof collection === 'object' && collection !== null) {
+  if (typeof collection === "object" && collection !== null) {
     return (function* () {
       for (const key in collection) {
-        if (collection.hasOwnProperty(key)) {
-          yield [key, (collection as Record<string|number|symbol, unknown>)[key]];
+        if (Object.prototype.hasOwnProperty.call(collection, key)) {
+          yield [
+            key,
+            (collection as Record<string | number | symbol, unknown>)[key],
+          ];
         }
       }
     })() as Iterable<T>;
@@ -85,7 +88,10 @@ export function toArray<T>(collection: Iterable<T> | Iterator<T>): Array<T> {
  * @param pairs
  */
 export function toMap<TKey, TValue>(
-  pairs: Iterable<[TKey, TValue]> | Iterator<[TKey, TValue]> | Record<RecordKey, unknown>
+  pairs:
+    | Iterable<[TKey, TValue]>
+    | Iterator<[TKey, TValue]>
+    | Record<RecordKey, unknown>
 ): Map<TKey, TValue> {
   const result: Map<TKey, TValue> = new Map();
   for (const [key, value] of toIterable(pairs)) {
@@ -99,9 +105,7 @@ export function toMap<TKey, TValue>(
  *
  * @param collection
  */
-export function toSet<T>(
-  collection: Iterable<T> | Iterator<T>
-): Set<T> {
+export function toSet<T>(collection: Iterable<T> | Iterator<T>): Set<T> {
   const result: Set<T> = new Set();
   for (const datum of toIterable(collection)) {
     result.add(datum);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,15 +1,16 @@
 import { InvalidArgumentError } from "./exceptions";
 import { isIterable, isIterator } from "./summary";
+import { Pair, RecordKey } from './types';
 
 /**
- * Converts collection to Iterable instance.
+ * Converts collection or record to Iterable instance.
  *
  * If instance is already an iterable then just return it.
  *
  * @param collection
  */
 export function toIterable<T>(
-  collection: Iterable<T> | Iterator<T>
+  collection: Iterable<T> | Iterator<T> | Record<RecordKey, unknown>
 ): Iterable<T> {
   if (isIterable(collection)) {
     return collection as Iterable<T>;
@@ -21,6 +22,16 @@ export function toIterable<T>(
         return collection as Iterator<T>;
       },
     };
+  }
+
+  if (typeof collection === 'object' && collection !== null) {
+    return (function* () {
+      for (const key in collection) {
+        if (collection.hasOwnProperty(key)) {
+          yield [key, (collection as Record<string|number|symbol, unknown>)[key]];
+        }
+      }
+    })() as Iterable<T>;
   }
 
   throw new InvalidArgumentError(
@@ -64,6 +75,36 @@ export function toArray<T>(collection: Iterable<T> | Iterator<T>): Array<T> {
   const result = [];
   for (const item of toIterable(collection)) {
     result.push(item);
+  }
+  return result;
+}
+
+/**
+ * Converts collection of key-value pairs to Map.
+ *
+ * @param pairs
+ */
+export function toMap<TKey, TValue>(
+  pairs: Iterable<[TKey, TValue]> | Iterator<[TKey, TValue]> | Record<RecordKey, unknown>
+): Map<TKey, TValue> {
+  const result: Map<TKey, TValue> = new Map();
+  for (const [key, value] of toIterable(pairs)) {
+    result.set(key, value);
+  }
+  return result;
+}
+
+/**
+ * Converts given collection to Set.
+ *
+ * @param collection
+ */
+export function toSet<T>(
+  collection: Iterable<T> | Iterator<T>
+): Set<T> {
+  const result: Set<T> = new Set();
+  for (const datum of toIterable(collection)) {
+    result.add(datum);
   }
   return result;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type RecordKey = string | number | symbol;
+
 export type Comparable = string | number | boolean | Array<unknown>;
 
 export type Pair<T> = [T, T];

--- a/tests/stream/transform.test.ts
+++ b/tests/stream/transform.test.ts
@@ -1,0 +1,387 @@
+// @ts-ignore
+import { createGeneratorFixture, createIterableFixture, createIteratorFixture, createMapFixture } from "../fixture";
+import { Stream } from '../../src';
+
+describe.each([
+  ...dataProviderForArrays(),
+  ...dataProviderForGenerators(),
+  ...dataProviderForIterables(),
+  ...dataProviderForIterators(),
+  ...dataProviderForStrings(),
+  ...dataProviderForSets(),
+  ...dataProviderForMaps(),
+] as Array<[Iterable<unknown>|Iterator<unknown>, (data: unknown) => Stream, Array<unknown>]>)(
+  "Stream Transform Test",
+  (
+    input: Iterable<unknown>|Iterator<unknown>,
+    streamFactory: (data: unknown) => Stream,
+    expected: Array<unknown>
+  ) => {
+    it("", () => {
+      // Given
+      const result = streamFactory(input);
+
+      // Then
+      expect(result).toEqual(expected);
+    });
+  }
+);
+
+function dataProviderForArrays(): Array<unknown> {
+  return [
+    [
+      [],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [1, 2, 3],
+    ],
+    [
+      [],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      [1, 1, 2, 2, 3, 3],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      [],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+    [
+      [['a', 1], ['b', 2], ['c', 3]],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      [['a', 1], ['a', 2], ['a', 3]],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 3]]),
+    ],
+  ];
+}
+
+function dataProviderForGenerators(): Array<unknown> {
+  return [
+    [
+      createGeneratorFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [1, 2, 3],
+    ],
+    [
+      createGeneratorFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createGeneratorFixture([1, 1, 2, 2, 3, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createGeneratorFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+    [
+      createGeneratorFixture([['a', 1], ['b', 2], ['c', 3]]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      createGeneratorFixture([['a', 1], ['a', 2], ['a', 3]]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 3]]),
+    ],
+  ];
+}
+
+function dataProviderForIterables(): Array<unknown> {
+  return [
+    [
+      createIterableFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [1, 2, 3],
+    ],
+    [
+      createIterableFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createIterableFixture([1, 1, 2, 2, 3, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createIterableFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+    [
+      createIterableFixture([['a', 1], ['b', 2], ['c', 3]]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      createIterableFixture([['a', 1], ['a', 2], ['a', 3]]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 3]]),
+    ],
+  ];
+}
+
+function dataProviderForIterators(): Array<unknown> {
+  return [
+    [
+      createIteratorFixture([]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      createIteratorFixture([1, 2, 3]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [1, 2, 3],
+    ],
+    [
+      createIteratorFixture([]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      createIteratorFixture([1, 2, 3]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createIteratorFixture([1, 1, 2, 2, 3, 3]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createIteratorFixture([]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+    [
+      createIteratorFixture([['a', 1], ['b', 2], ['c', 3]]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      createIteratorFixture([['a', 1], ['a', 2], ['a', 3]]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 3]]),
+    ],
+  ];
+}
+
+function dataProviderForStrings(): Array<unknown> {
+  return [
+    [
+      '',
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      '123',
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      ['1', '2', '3'],
+    ],
+    [
+      '',
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      '123',
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set(['1', '2', '3']),
+    ],
+    [
+      '112233',
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set(['1', '2', '3']),
+    ],
+    [
+      '',
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+  ];
+}
+
+function dataProviderForSets(): Array<unknown> {
+  return [
+    [
+      new Set([]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [1, 2, 3],
+    ],
+    [
+      new Set([]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      new Set([1, 1, 2, 2, 3, 3]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([1, 2, 3]),
+    ],
+    [
+      new Set([]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+    [
+      new Set([['a', 1], ['b', 2], ['c', 3]]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      new Set([['a', 1], ['a', 2], ['a', 3]]),
+      (iterable: Iterator<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 3]]),
+    ],
+  ];
+}
+
+function dataProviderForMaps(): Array<unknown> {
+  return [
+    [
+      createMapFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [],
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toArray(),
+      [[0, 1], [1, 2], [2, 3]],
+    ],
+    [
+      createMapFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([]),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([[0, 1], [1, 2], [2, 3]]),
+    ],
+    [
+      createMapFixture([1, 1, 2, 2, 3, 3]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toSet(),
+      new Set([[0, 1], [1, 1], [2, 2], [3, 2], [4, 3], [5, 3]]),
+    ],
+    [
+      createMapFixture([]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([]),
+    ],
+    [
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      new Map([['a', 1], ['a', 2], ['a', 3]]),
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .toMap(),
+      new Map([['a', 3]]),
+    ],
+  ];
+}

--- a/tests/transform/to-iterable.test.ts
+++ b/tests/transform/to-iterable.test.ts
@@ -91,6 +91,18 @@ function dataProviderForSuccess(): Array<unknown> {
       new Map([['a', 1], ['b', 2], ['c', 3]]),
       [['a', 1], ['b', 2], ['c', 3]],
     ],
+    [
+      {},
+      [],
+    ],
+    [
+      {a: 1, b: 2, c: 3},
+      [['a', 1], ['b', 2], ['c', 3]],
+    ],
+    [
+      {a: [1], b: {x: 2}, c: 3},
+      [['a', [1]], ['b', {x: 2}], ['c', 3]],
+    ],
   ];
 }
 
@@ -116,6 +128,5 @@ function dataProviderForError(): Array<unknown> {
     [NaN],
     [Infinity],
     [-Infinity],
-    [{a: 1}],
   ];
 }

--- a/tests/transform/to-map.test.ts
+++ b/tests/transform/to-map.test.ts
@@ -1,0 +1,93 @@
+// @ts-ignore
+import { createGeneratorFixture, createIterableFixture } from '../fixture';
+import { transform, single } from '../../src';
+
+describe.each(dataProvider() as Array<[Iterable<[unknown, unknown]>|Iterator<[unknown, unknown]>, Map<unknown, unknown>]>)(
+  "Transform To Map Test",
+  (
+    input: Iterable<[unknown, unknown]>|Iterator<[unknown, unknown]>,
+    expected: Map<unknown, unknown>
+  ) => {
+    it("", () => {
+      // Given
+      const result = transform.toMap(input);
+
+      // Then
+      expect(result instanceof Map).toBeTruthy();
+      expect(result).toEqual(expected);
+    });
+  }
+);
+
+function dataProvider(): Array<unknown> {
+  return [
+    [
+      single.enumerate(''),
+      new Map([]),
+    ],
+    [
+      single.enumerate('123'),
+      new Map([[0, '1'], [1, '2'], [2, '3']]),
+    ],
+    [
+      [],
+      new Map([]),
+    ],
+    [
+      [['a', 1], ['b', 2], ['c', 3]],
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+    [
+      createGeneratorFixture([]),
+      new Map([]),
+    ],
+    [
+      createGeneratorFixture([['a', 1]]),
+      new Map([['a', 1]]),
+    ],
+    [
+      createGeneratorFixture([[1, 1], [2, 2], [3, 3]]),
+      new Map([[1, 1], [2, 2], [3, 3]]),
+    ],
+    [
+      createIterableFixture([]),
+      new Map([]),
+    ],
+    [
+      createIterableFixture([[0, 1]]),
+      new Map([[0, 1]]),
+    ],
+    [
+      createIterableFixture([[1, 1], [2, 2], [3, 3]]),
+      new Map([[1, 1], [2, 2], [3, 3]]),
+    ],
+    [
+      new Set(),
+      new Map(),
+    ],
+    [
+      new Set([['a', 1]]),
+      new Map([['a', 1]]),
+    ],
+    [
+      new Set([['a', 1], ['a', 1], ['a', 1]]),
+      new Map([['a', 1]]),
+    ],
+    [
+      new Set([[1, 1], [2, 2], [3, 3]]),
+      new Map([[1, 1], [2, 2], [3, 3]]),
+    ],
+    [
+      new Map(),
+      new Map(),
+    ],
+    [
+      new Map([['a', 1]]),
+      new Map([['a', 1]]),
+    ],
+    [
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+  ];
+}

--- a/tests/transform/to-set.test.ts
+++ b/tests/transform/to-set.test.ts
@@ -1,0 +1,109 @@
+// @ts-ignore
+import { createGeneratorFixture, createIterableFixture } from '../fixture';
+import { transform } from '../../src';
+
+describe.each(dataProvider() as Array<[Iterable<unknown>|Iterator<unknown>, Array<unknown>]>)(
+  "Transform To Set Test",
+  (
+    input: Iterable<unknown>|Iterator<unknown>,
+    expected: Array<unknown>
+  ) => {
+    it("", () => {
+      // Given
+      const result = transform.toSet(input);
+
+      // Then
+      expect(result instanceof Set).toBeTruthy();
+      expect(result).toEqual(expected);
+    });
+  }
+);
+
+function dataProvider(): Array<unknown> {
+  return [
+    [
+      '',
+      new Set([]),
+    ],
+    [
+      '123',
+      new Set(['1', '2', '3']),
+    ],
+    [
+      '112233',
+      new Set(['1', '2', '3']),
+    ],
+    [
+      [],
+      new Set([]),
+    ],
+    [
+      [1, 2, 3],
+      new Set([1, 2, 3]),
+    ],
+    [
+      [1, 1, 2, 2, 3, 3],
+      new Set([1, 2, 3]),
+    ],
+    [
+      createGeneratorFixture([]),
+      new Set([]),
+    ],
+    [
+      createGeneratorFixture([1]),
+      new Set([1]),
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createGeneratorFixture([1, 1, 2, 2, 3, 3]),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createIterableFixture([]),
+      new Set([]),
+    ],
+    [
+      createIterableFixture([1]),
+      new Set([1]),
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      new Set([1, 2, 3]),
+    ],
+    [
+      createIterableFixture([1, 1, 2, 2, 3, 3]),
+      new Set([1, 2, 3]),
+    ],
+    [
+      new Set(),
+      new Set([]),
+    ],
+    [
+      new Set([1]),
+      new Set([1]),
+    ],
+    [
+      new Set([1, 2, 3]),
+      new Set([1, 2, 3]),
+    ],
+    [
+      new Set([1, 1, 2, 2, 3, 3]),
+      new Set([1, 2, 3]),
+    ],
+    [
+      new Map(),
+      new Set([]),
+    ],
+    [
+      new Map([['a', 1]]),
+      new Set([['a', 1]]),
+    ],
+    [
+      new Map([['a', 1], ['b', 2], ['c', 3]]),
+      new Set([['a', 1], ['b', 2], ['c', 3]]),
+    ],
+  ];
+}


### PR DESCRIPTION
### New Features
* transform
  * `toMap()`
  * `toSet()`
* Stream
  * `toMap()`
  * `toSet()`
* types
  * `RecordKey`

### Improvements
* `transform.toIterable()` now can also accept records as input.
