### PR TITLE
Union return type in groupBy replaced by inferred type

### DIFF
--- a/.github/workflows/test_master.yml
+++ b/.github/workflows/test_master.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
+        node-version: [14.x, 16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # IterTools Typescript Change Log
 
+## v1.29.1 - 2025-01-23
+
+### Improvements
+* single
+  * `groupBy()` — union return type has been replaced by inferred type.
+  * `groupByAsync()` — union return type has been replaced by inferred type.
+
 ## v1.29.0 - 2024-12-24
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -660,11 +660,15 @@ Group data by a common data element.
 Iterate pairs of group name and collection of grouped items.
 
 ```
-function* groupBy<T>(
+export function* groupBy<
+  T,
+  TItemKeyFunction extends ((item: T) => string) | undefined,
+  TResultItem extends TItemKeyFunction extends undefined ? [string, Array<T>] : [string, Record<string, T>]
+>(
   data: Iterable<T> | Iterator<T>,
   groupKeyFunction: (item: T) => string,
-  itemKeyFunction?: (item: T) => string,
-): Iterable<[string, Array<T>] | [string, Record<string, T>]>
+  itemKeyFunction?: TItemKeyFunction
+): Iterable<TResultItem>
 ```
 
 * The `groupKeyFunction` determines the key to group elements by.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itertools-ts",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Extended itertools port for TypeScript and JavaScript. Provides a huge set of functions for working with iterable collections (including async ones)",
   "license": "MIT",
   "repository": {

--- a/src/single.ts
+++ b/src/single.ts
@@ -868,19 +868,29 @@ export async function* valuesAsync<TKey, TValue>(
  *
  * Collection of grouped items may be an array or an object (depends on presence of `itemKeyFunction` param).
  *
- * The `groupKeyFunction` determines the key (or multiple keys) to group elements by.
- *
- * The `itemKeyFunction` (optional) determines the key of element in group.
- *
  * @param data
- * @param groupKeyFunction
- * @param itemKeyFunction
+ * @param groupKeyFunction - determines the key (or multiple keys) to group elements by.
+ * @param itemKeyFunction - (optional) determines the key of element in group.
  */
-export function* groupBy<T>(
+// export function groupBy<T>(
+//   data: Iterable<T> | Iterator<T>,
+//   groupKeyFunction: (item: T) => string,
+//   itemKeyFunction?: undefined
+// ): Iterable<[string, Array<T>]>;
+// export function groupBy<T>(
+//   data: Iterable<T> | Iterator<T>,
+//   groupKeyFunction: (item: T) => string,
+//   itemKeyFunction: (item: T) => string
+// ): Iterable<[string, Record<string, T>]>;
+export function* groupBy<
+  T,
+  TItemKeyFunction extends ((item: T) => string) | undefined,
+  TResultItem extends TItemKeyFunction extends undefined ? [string, Array<T>] : [string, Record<string, T>]
+>(
   data: Iterable<T> | Iterator<T>,
   groupKeyFunction: (item: T) => string,
-  itemKeyFunction?: (item: T) => string
-): Iterable<[string, Array<T>] | [string, Record<string, T>]> {
+  itemKeyFunction?: TItemKeyFunction
+): Iterable<TResultItem> {
   const groups = new Map();
   const addGroup = (name: string) => {
     if (!groups.has(name)) {
@@ -913,7 +923,7 @@ export function* groupBy<T>(
   }
 
   for (const group of groups) {
-    yield group;
+    yield group as TResultItem;
   }
 }
 
@@ -924,21 +934,30 @@ export function* groupBy<T>(
  *
  * Collection of grouped items may be an array or an object (depends on presence of `itemKeyFunction` param).
  *
- * The `groupKeyFunction` determines the key (or multiple keys) to group elements by.
- *
- * The `itemKeyFunction` (optional) determines the key of element in group.
- *
  * Functions `groupKeyFunction` and `itemKeyFunction` may be async.
  *
  * @param data
- * @param groupKeyFunction
- * @param itemKeyFunction
+ * @param groupKeyFunction - determines the key (or multiple keys) to group elements by.
+ * @param itemKeyFunction - (optional) determines the key of element in group.
  */
-export async function* groupByAsync<T>(
+// export function groupByAsync<T>(
+//   data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+//   groupKeyFunction: (item: T) => string | Promise<string>,
+//   itemKeyFunction: (item: T) => string | Promise<string>
+// ): AsyncIterable<[string, Record<string, T>]>;
+// export function groupByAsync<T>(
+//   data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+//   groupKeyFunction: (item: T) => string | Promise<string>
+// ): AsyncIterable<[string, Array<T>]>;
+export async function* groupByAsync<
+  T,
+  TItemKeyFunction extends ((item: T) => string) | undefined,
+  TResultItem extends TItemKeyFunction extends undefined ? [string, Array<T>] : [string, Record<string, T>]
+>(
   data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
-  groupKeyFunction: (item: T) => string | Promise<string>,
-  itemKeyFunction?: (item: T) => string | Promise<string>
-): AsyncIterable<[string, Array<T>] | [string, Record<string, T>]> {
+  groupKeyFunction: (item: T) => (string | Promise<string>),
+  itemKeyFunction?: (item: T) => (string | Promise<string>)
+): AsyncIterable<TResultItem> {
   const groups = new Map();
   const addGroup = (name: string) => {
     if (!groups.has(name)) {
@@ -972,7 +991,7 @@ export async function* groupByAsync<T>(
   }
 
   for (const group of groups) {
-    yield group;
+    yield group as TResultItem;
   }
 }
 

--- a/src/single.ts
+++ b/src/single.ts
@@ -872,16 +872,6 @@ export async function* valuesAsync<TKey, TValue>(
  * @param groupKeyFunction - determines the key (or multiple keys) to group elements by.
  * @param itemKeyFunction - (optional) determines the key of element in group.
  */
-// export function groupBy<T>(
-//   data: Iterable<T> | Iterator<T>,
-//   groupKeyFunction: (item: T) => string,
-//   itemKeyFunction?: undefined
-// ): Iterable<[string, Array<T>]>;
-// export function groupBy<T>(
-//   data: Iterable<T> | Iterator<T>,
-//   groupKeyFunction: (item: T) => string,
-//   itemKeyFunction: (item: T) => string
-// ): Iterable<[string, Record<string, T>]>;
 export function* groupBy<
   T,
   TItemKeyFunction extends ((item: T) => string) | undefined,
@@ -940,15 +930,6 @@ export function* groupBy<
  * @param groupKeyFunction - determines the key (or multiple keys) to group elements by.
  * @param itemKeyFunction - (optional) determines the key of element in group.
  */
-// export function groupByAsync<T>(
-//   data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
-//   groupKeyFunction: (item: T) => string | Promise<string>,
-//   itemKeyFunction: (item: T) => string | Promise<string>
-// ): AsyncIterable<[string, Record<string, T>]>;
-// export function groupByAsync<T>(
-//   data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
-//   groupKeyFunction: (item: T) => string | Promise<string>
-// ): AsyncIterable<[string, Array<T>]>;
 export async function* groupByAsync<
   T,
   TItemKeyFunction extends ((item: T) => string) | undefined,


### PR DESCRIPTION
### Improvements
* single
  * `groupBy()` — union return type has been replaced by inferred type.
  * `groupByAsync()` — union return type has been replaced by inferred type.
