### PR TITLE
use `export * from` syntax. this retains JSDoc and cuts repetition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,384 +1,43 @@
-import {
-  chunkwise,
-  chunkwiseOverlap,
-  compress,
-  dropWhile,
-  enumerate,
-  filter,
-  flatMap,
-  flatten,
-  groupBy,
-  keys,
-  limit,
-  map,
-  pairwise,
-  repeat,
-  skip,
-  slice,
-  sort,
-  takeWhile,
-  values,
-  chunkwiseAsync,
-  chunkwiseOverlapAsync,
-  compressAsync,
-  dropWhileAsync,
-  enumerateAsync,
-  filterAsync,
-  flatMapAsync,
-  flattenAsync,
-  groupByAsync,
-  keysAsync,
-  limitAsync,
-  mapAsync,
-  pairwiseAsync,
-  repeatAsync,
-  skipAsync,
-  sliceAsync,
-  sortAsync,
-  takeWhileAsync,
-  valuesAsync,
-} from "./single";
 
-import { count, cycle, cycleAsync, repeat as infiniteRepeat, booleans, booleansAsync } from "./infinite";
+export * as math from "./math";
 
-import {
-  runningAverage,
-  runningDifference,
-  runningMax,
-  runningMin,
-  runningProduct,
-  runningTotal,
-  runningAverageAsync,
-  runningDifferenceAsync,
-  runningMaxAsync,
-  runningMinAsync,
-  runningProductAsync,
-  runningTotalAsync,
-} from "./math";
+export * as multi from "./multi";
 
-import {
-  chain,
-  zip,
-  zipFilled,
-  zipLongest,
-  zipEqual,
-  chainAsync,
-  zipAsync,
-  zipFilledAsync,
-  zipLongestAsync,
-  zipEqualAsync,
-} from "./multi";
+export * as combinatorics from "./combinatorics";
 
-import {
-  distinct,
-  intersection,
-  partialIntersection,
-  symmetricDifference,
-  union,
-  cartesianProduct as cartesianProductDeprecated,
-  distinctAsync,
-  intersectionAsync,
-  partialIntersectionAsync,
-  symmetricDifferenceAsync,
-  unionAsync,
-  cartesianProductAsync as cartesianProductAsyncDeprecated,
-} from "./set";
+export * as reduce from "./reduce";
 
-import {
-  cartesianProduct,
-  permutations,
-  combinations,
-  cartesianProductAsync,
-  permutationsAsync,
-  combinationsAsync,
-} from "./combinatorics";
+export { Stream } from "./stream";
 
-import {
-  toAverage,
-  toCount,
-  toMax,
-  toMin,
-  toMinMax,
-  toProduct,
-  toRange,
-  toSum,
-  toValue,
-  toFirst,
-  toFirstAndLast,
-  toLast,
-  toAverageAsync,
-  toCountAsync,
-  toFirstAsync,
-  toFirstAndLastAsync,
-  toLastAsync,
-  toMaxAsync,
-  toMinAsync,
-  toMinMaxAsync,
-  toProductAsync,
-  toRangeAsync,
-  toSumAsync,
-  toValueAsync,
-} from "./reduce";
+export { AsyncStream } from "./async-stream";
 
-import { Stream } from "./stream";
+export * as summary from "./summary";
 
-import { AsyncStream } from "./async-stream";
+export * as transform from "./transform";
 
-import {
-  allMatch,
-  allUnique,
-  anyMatch,
-  exactlyN,
-  isEmpty,
-  isAsyncIterable,
-  isIterable,
-  isIterator,
-  isReversed,
-  isSorted,
-  isString,
-  noneMatch,
-  same,
-  sameCount,
-  allMatchAsync,
-  allUniqueAsync,
-  anyMatchAsync,
-  exactlyNAsync,
-  isEmptyAsync,
-  isReversedAsync,
-  isSortedAsync,
-  noneMatchAsync,
-  sameAsync,
-  sameCountAsync,
-} from "./summary";
+export { createPipe } from "./pipe";
 
-import {
-  tee,
-  toArray,
-  toAsyncIterable,
-  toAsyncIterator,
-  toIterable,
-  toIterator,
-  toMap,
-  toSet,
-  teeAsync,
-  toArrayAsync,
-  toMapAsync,
-  toSetAsync,
-} from "./transform";
+export { InvalidArgumentError, LengthError } from "./exceptions";
 
-import { createPipe } from "./pipe";
-
-import { InvalidArgumentError, LengthError } from "./exceptions";
-
-import type {
-  Numeric,
-  NumericString,
-  AsyncFlatMapper,
-  FlatMapper,
-  Pair,
-  Comparable,
-  Comparator,
+export type {
   RecordKey,
+  Comparable,
+  NumericString,
+  Numeric,
+  Comparator,
+  Pair,
+  First,
+  Last,
+  FlatMapper,
+  AsyncFlatMapper,
   ZipTuple,
   PipeOperation,
   PipeOperationSequence,
   Pipe,
 } from "./types";
 
-export const single = {
-  chunkwise,
-  chunkwiseOverlap,
-  compress,
-  dropWhile,
-  enumerate,
-  filter,
-  flatMap,
-  flatten,
-  groupBy,
-  keys,
-  limit,
-  map,
-  pairwise,
-  repeat,
-  skip,
-  slice,
-  sort,
-  takeWhile,
-  values,
-  chunkwiseAsync,
-  chunkwiseOverlapAsync,
-  compressAsync,
-  dropWhileAsync,
-  enumerateAsync,
-  filterAsync,
-  flatMapAsync,
-  flattenAsync,
-  groupByAsync,
-  keysAsync,
-  limitAsync,
-  mapAsync,
-  pairwiseAsync,
-  repeatAsync,
-  skipAsync,
-  sliceAsync,
-  sortAsync,
-  takeWhileAsync,
-  valuesAsync,
-};
+export * as single from './single';
 
-export const infinite = {
-  count,
-  cycle,
-  cycleAsync,
-  repeat: infiniteRepeat,
-  booleans,
-  booleansAsync,
-};
+export * as infinite from "./infinite";
 
-export const math = {
-  runningAverage,
-  runningDifference,
-  runningMax,
-  runningMin,
-  runningProduct,
-  runningTotal,
-  runningAverageAsync,
-  runningDifferenceAsync,
-  runningMaxAsync,
-  runningMinAsync,
-  runningProductAsync,
-  runningTotalAsync,
-};
-
-export const multi = {
-  chain,
-  zip,
-  zipFilled,
-  zipLongest,
-  zipEqual,
-  chainAsync,
-  zipAsync,
-  zipFilledAsync,
-  zipLongestAsync,
-  zipEqualAsync,
-};
-
-export const set = {
-  distinct,
-  intersection,
-  partialIntersection,
-  symmetricDifference,
-  union,
-  distinctAsync,
-  intersectionAsync,
-  partialIntersectionAsync,
-  symmetricDifferenceAsync,
-  unionAsync,
-  /**
-   * @deprecated Use `combinatorics.cartesianProduct()` instead.
-   */
-  cartesianProduct: cartesianProductDeprecated,
-  /**
-   * @deprecated Use `combinatorics.cartesianProductAsync()` instead.
-   */
-  cartesianProductAsync: cartesianProductAsyncDeprecated,
-};
-
-export const combinatorics = {
-  cartesianProduct,
-  permutations,
-  combinations,
-  cartesianProductAsync,
-  permutationsAsync,
-  combinationsAsync,
-};
-
-export const reduce = {
-  toAverage,
-  toCount,
-  toFirst,
-  toFirstAndLast,
-  toLast,
-  toMax,
-  toMin,
-  toMinMax,
-  toProduct,
-  toRange,
-  toSum,
-  toValue,
-  toAverageAsync,
-  toCountAsync,
-  toFirstAsync,
-  toFirstAndLastAsync,
-  toLastAsync,
-  toMaxAsync,
-  toMinAsync,
-  toMinMaxAsync,
-  toProductAsync,
-  toRangeAsync,
-  toSumAsync,
-  toValueAsync,
-};
-
-export const summary = {
-  allMatch,
-  allUnique,
-  anyMatch,
-  exactlyN,
-  isEmpty,
-  isAsyncIterable,
-  isIterable,
-  isIterator,
-  isReversed,
-  isSorted,
-  isString,
-  noneMatch,
-  same,
-  sameCount,
-  allMatchAsync,
-  allUniqueAsync,
-  anyMatchAsync,
-  exactlyNAsync,
-  isEmptyAsync,
-  isReversedAsync,
-  isSortedAsync,
-  noneMatchAsync,
-  sameAsync,
-  sameCountAsync,
-};
-
-export const transform = {
-  tee,
-  toArray,
-  toAsyncIterable,
-  toAsyncIterator,
-  toIterable,
-  toIterator,
-  toMap,
-  toSet,
-  teeAsync,
-  toArrayAsync,
-  toMapAsync,
-  toSetAsync,
-};
-
-export { Stream, AsyncStream };
-
-export { createPipe };
-
-export type {
-  Numeric,
-  NumericString,
-  AsyncFlatMapper,
-  FlatMapper,
-  Pair,
-  Comparable,
-  Comparator,
-  RecordKey,
-  ZipTuple,
-  PipeOperation,
-  PipeOperationSequence,
-  Pipe,
-};
-
-export { InvalidArgumentError, LengthError };
+export * as set from "./set";


### PR DESCRIPTION
Your JSDoc was not actually showing up.
<img width="856" height="249" alt="image" src="https://github.com/user-attachments/assets/c41b8bb6-6c37-4992-b206-764999e5841b" />

Fixed:
<img width="844" height="246" alt="image" src="https://github.com/user-attachments/assets/e8f3701f-d63b-43ba-a964-bcaa3b5f9725" />
