### PR TITLE
Add random rock-paper-scissors generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,11 @@ Quick Reference
 | [`repeat`](#Repeat-1)   | Repeat an item forever     | `infinite.repeat(item)`            |
 
 #### Random Iteration
-| Iterator                    | Description                | Code Snippet                       |
-|-----------------------------|----------------------------|------------------------------------|
-| [`booleans`](#Booleans)     | Generate random booleans   | `random.booleans([repetitions])`   |
-| [`percentage`](#Percentage) | Generate random percentage | `random.percentage([repetitions])` |
+| Iterator                                      | Description                            | Code Snippet                                  |
+|-----------------------------------------------|----------------------------------------|-----------------------------------------------|
+| [`booleans`](#Booleans)                       | Generate random booleans               | `random.booleans([repetitions])`              |
+| [`percentage`](#Percentage)                   | Generate random percentage             | `random.percentage([repetitions])`            |
+| [`rockPaperScissors`](#Rock-Paper-Scissors)   | Generate random rock-paper-scissors    | `random.rockPaperScissors([repetitions])`     |
 
 #### Math Iteration
 | Iterator                                   | Description                     | Sync Code Snippet                                 | Async Code Snippet                                     |
@@ -259,15 +260,16 @@ Quick Reference
 
 ### Stream and AsyncStream Iteration Tools
 #### Stream Sources
-| Source                           | Description                         | Sync Code Snippet                  | Async Code Snippet                      |
-|----------------------------------|-------------------------------------|------------------------------------|-----------------------------------------|
-| [`of`](#of)                      | Create a stream from an iterable    | `Stream.of(iterable)`              | `AsyncStream.of(iterable)`              |
-| [`ofCount`](#of-count)           | Create an infinite count stream     | `Stream.ofCount([start], [step])`  | `AsyncStream.ofCount([start], [step])`  |
-| [`ofBooleans`](#of-booleans)     | Create booleans stream              | `Stream.ofBooleans([repetitions])` | `AsyncStream.ofBooleans([repetitions])` |
-| [`ofCycle`](#of-cycle)           | Create an infinite cycle stream     | `Stream.ofCycle(iterable)`         | `AsyncStream.ofCycle(iterable)`         |
-| [`ofEmpty`](#of-empty)           | Create an empty stream              | `Stream.ofEmpty()`                 | `AsyncStream.ofEmpty()`                 |
-| [`ofPercentage`](#of-percentage) | Create percentage stream            | `Stream.ofPercentage(item)`        | `AsyncStream.ofPercentage(item)`        |
-| [`ofRepeat`](#of-repeat)         | Create an infinite repeating stream | `Stream.ofRepeat(item)`            | `AsyncStream.ofRepeat(item)`            |
+| Source                                           | Description                              | Sync Code Snippet                         | Async Code Snippet                             |
+|--------------------------------------------------|------------------------------------------|-------------------------------------------|------------------------------------------------|
+| [`of`](#of)                                      | Create a stream from an iterable         | `Stream.of(iterable)`                     | `AsyncStream.of(iterable)`                     |
+| [`ofCount`](#of-count)                           | Create an infinite count stream          | `Stream.ofCount([start], [step])`         | `AsyncStream.ofCount([start], [step])`         |
+| [`ofBooleans`](#of-booleans)                     | Create booleans stream                   | `Stream.ofBooleans([repetitions])`        | `AsyncStream.ofBooleans([repetitions])`        |
+| [`ofCycle`](#of-cycle)                           | Create an infinite cycle stream          | `Stream.ofCycle(iterable)`                | `AsyncStream.ofCycle(iterable)`                |
+| [`ofEmpty`](#of-empty)                           | Create an empty stream                   | `Stream.ofEmpty()`                        | `AsyncStream.ofEmpty()`                        |
+| [`ofPercentage`](#of-percentage)                 | Create percentage stream                 | `Stream.ofPercentage(item)`               | `AsyncStream.ofPercentage(item)`               |
+| [`ofRepeat`](#of-repeat)                         | Create an infinite repeating stream      | `Stream.ofRepeat(item)`                   | `AsyncStream.ofRepeat(item)`                   |
+| [`ofRockPaperScissors`](#of-rock-paper-scissors) | Create rock-paper-scissors stream        | `Stream.ofRockPaperScissors([repetitions])` | `AsyncStream.ofRockPaperScissors([repetitions])` |
 
 #### Stream Operations
 | Operation                                               | Description                                                                               | Code Snippet                                                         |
@@ -1039,6 +1041,35 @@ for (const item of infinite.repeat('bla')) {
 ```
 
 ## Random Iteration
+
+### Rock Paper Scissors
+Generate random rock-paper-scissors values.
+
+```
+function* rockPaperScissors(repetitions?: number): Iterable<"rock" | "paper" | "scissors">
+```
+
+If `repetitions` is provided, generates exactly that many values. If not provided, generates values infinitely.
+
+```typescript
+import { random } from 'itertools-ts';
+
+for (const value of random.rockPaperScissors(5)) {
+  console.log(value);
+}
+// 'rock', 'scissors', 'paper', 'rock', 'paper' (random values)
+
+for (const value of random.rockPaperScissors()) {
+  console.log(value);
+}
+// 'rock', 'scissors', 'paper', ... (infinite random values)
+
+// Async version
+for await (const value of random.rockPaperScissorsAsync(5)) {
+  console.log(value);
+}
+// 'paper', 'rock', 'scissors', 'paper', 'rock' (random values)
+```
 
 ### Percentage
 Generate random percentage values.
@@ -2332,6 +2363,26 @@ const result1 = Stream.ofBooleans()
 const result2 = Stream.ofBooleans(5)
   .toArray();
 // [false, true, true, false, true]
+```
+
+#### Of Rock Paper Scissors
+Create a rock-paper-scissors stream.
+
+```
+Stream.ofRockPaperScissors(repetitions?: number): Stream<"rock" | "paper" | "scissors">
+AsyncStream.ofRockPaperScissors(repetitions?: number): AsyncStream<"rock" | "paper" | "scissors">
+```
+
+```typescript
+import { Stream, AsyncStream } from "itertools-ts";
+
+const result = Stream.ofRockPaperScissors(5)
+  .toArray();
+// ['rock', 'scissors', 'paper', 'rock', 'paper']
+
+const asyncResult = await AsyncStream.ofRockPaperScissors(5)
+  .toArray();
+// ['paper', 'rock', 'scissors', 'paper', 'rock']
 ```
 
 #### Of Count

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -88,6 +88,19 @@ export class AsyncStream<T> implements AsyncIterable<T> {
   }
 
   /**
+   * Generate random rock-paper-scissors values asynchronously.
+   *
+   * If optional param `repetitions` is not given, iterates infinitely.
+   *
+   * @param repetitions - Number of values to generate
+   *
+   * @see random.rockPaperScissorsAsync
+   */
+  static ofRockPaperScissors(repetitions?: number): AsyncStream<"rock" | "paper" | "scissors"> {
+    return new AsyncStream(random.rockPaperScissorsAsync(repetitions));
+  }
+
+  /**
    * Generate random percentages between 0 (inclusive) and 1 (exclusive) asynchronously.
    *
    * If optional param `repetitions` is not given, iterates infinitely.

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,5 +1,14 @@
 import { InvalidArgumentError } from "./exceptions";
 
+const ROCK_PAPER_SCISSORS_VALUES = ["rock", "paper", "scissors"] as const;
+type RockPaperScissors = typeof ROCK_PAPER_SCISSORS_VALUES[number];
+
+function randomRockPaperScissors(): RockPaperScissors {
+  return ROCK_PAPER_SCISSORS_VALUES[
+    Math.floor(Math.random() * ROCK_PAPER_SCISSORS_VALUES.length)
+  ];
+}
+
 /**
  * Generate a sequence of random booleans
  *
@@ -29,6 +38,48 @@ export async function* booleansAsync(repetitions?: number): AsyncIterable<boolea
   while (repetitions === undefined || i < repetitions) {
     yield Math.random() > 0.5;
     i++;
+  }
+}
+
+/**
+ * Generate a sequence of random rock-paper-scissors values.
+ *
+ * If optional param `repetitions` is not given, iterates infinitely.
+ *
+ * @param repetitions - Number of values to generate
+ * @throws {InvalidArgumentError} If repetitions is negative
+ * @see rockPaperScissorsAsync For asynchronous version
+ */
+export function* rockPaperScissors(repetitions?: number): Iterable<RockPaperScissors> {
+  if (repetitions !== undefined && repetitions < 0) {
+    throw new InvalidArgumentError(`Number of repetitions cannot be negative: ${repetitions}`);
+  }
+
+  let count = 0;
+  while (repetitions === undefined || count < repetitions) {
+    yield randomRockPaperScissors();
+    if (repetitions !== undefined) count++;
+  }
+}
+
+/**
+ * Generate a sequence of random rock-paper-scissors values asynchronously.
+ *
+ * If optional param `repetitions` is not given, iterates infinitely.
+ *
+ * @param repetitions - Number of values to generate
+ * @throws {InvalidArgumentError} If repetitions is negative
+ * @see rockPaperScissors For synchronous version
+ */
+export async function* rockPaperScissorsAsync(repetitions?: number): AsyncIterable<RockPaperScissors> {
+  if (repetitions !== undefined && repetitions < 0) {
+    throw new InvalidArgumentError(`Number of repetitions cannot be negative: ${repetitions}`);
+  }
+
+  let count = 0;
+  while (repetitions === undefined || count < repetitions) {
+    yield randomRockPaperScissors();
+    if (repetitions !== undefined) count++;
   }
 }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -82,6 +82,19 @@ export class Stream<T> implements Iterable<T> {
   }
 
   /**
+   * Generate random rock-paper-scissors values.
+   *
+   * If optional param `repetitions` is not given, iterates infinitely.
+   *
+   * @param repetitions - Number of values to generate
+   *
+   * @see random.rockPaperScissors
+   */
+  static ofRockPaperScissors(repetitions?: number): Stream<"rock" | "paper" | "scissors"> {
+    return new Stream(random.rockPaperScissors(repetitions));
+  }
+
+  /**
    * Generate random percentages between 0 (inclusive) and 1 (exclusive).
    *
    * If optional param `repetitions` is not given, iterates infinitely.

--- a/tests/async-stream/random.test.ts
+++ b/tests/async-stream/random.test.ts
@@ -3,6 +3,8 @@ import { InvalidArgumentError } from '../../src/exceptions';
 import { AsyncStream } from '../../src/async-stream';
 
 
+const ROCK_PAPER_SCISSORS_VALUES = ['rock', 'paper', 'scissors'];
+
 describe.each([
   ...dataProviderForFiniteAsync(),
 ])(
@@ -89,6 +91,32 @@ describe.each([
         expect(num).toBeGreaterThanOrEqual(0);
         expect(num).toBeLessThan(1);
       });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForStreamWrapperAsync(),
+])(
+  'AsyncStream.ofRockPaperScissors()',
+  (count) => {
+    it('', async () => {
+      const values = await AsyncStream.ofRockPaperScissors(count).toArray();
+      expect(values.length).toBe(count);
+      values.forEach((value) => {
+        expect(ROCK_PAPER_SCISSORS_VALUES).toContain(value);
+      });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForNegativeAsync(),
+])(
+  'AsyncStream.ofRockPaperScissors() negative',
+  (negativeCount) => {
+    it('', async () => {
+      await expect(AsyncStream.ofRockPaperScissors(negativeCount).toArray()).rejects.toThrow(InvalidArgumentError);
     });
   }
 );

--- a/tests/random/rock-paper-scissors.test.ts
+++ b/tests/random/rock-paper-scissors.test.ts
@@ -1,0 +1,166 @@
+import { rockPaperScissors, rockPaperScissorsAsync } from '../../src/random';
+import { InvalidArgumentError } from '../../src/exceptions';
+
+const ROCK_PAPER_SCISSORS_VALUES = ['rock', 'paper', 'scissors'];
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe.each([
+  ...dataProviderForFiniteSync(),
+])(
+  'Random Rock Paper Scissors Finite (sync)',
+  (count) => {
+    it('', () => {
+      const values = Array.from(rockPaperScissors(count));
+      expect(values.length).toBe(count);
+      values.forEach((value) => {
+        expect(ROCK_PAPER_SCISSORS_VALUES).toContain(value);
+      });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForInfiniteSync(),
+])(
+  'Random Rock Paper Scissors Infinite (sync)',
+  (takeCount) => {
+    it('', () => {
+      const gen = rockPaperScissors()[Symbol.iterator]();
+      const values: Array<string> = [];
+      for (let i = 0; i < takeCount; i++) {
+        const { value, done } = gen.next();
+        if (done) break;
+        values.push(value);
+      }
+      expect(values.length).toBe(takeCount);
+      values.forEach((value) => {
+        expect(ROCK_PAPER_SCISSORS_VALUES).toContain(value);
+      });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForNegativeSync(),
+])(
+  'Random Rock Paper Scissors Negative (sync)',
+  (negativeCount) => {
+    it('', () => {
+      expect(() => Array.from(rockPaperScissors(negativeCount))).toThrow(InvalidArgumentError);
+    });
+  }
+);
+
+describe(
+  'Random Rock Paper Scissors Deterministic (sync)',
+  () => {
+    it('', () => {
+      jest.spyOn(Math, 'random')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0.34)
+        .mockReturnValueOnce(0.99);
+
+      expect(Array.from(rockPaperScissors(3))).toEqual(['rock', 'paper', 'scissors']);
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForFiniteAsync(),
+])(
+  'Random Rock Paper Scissors Finite (async)',
+  (count) => {
+    it('', async () => {
+      const values: Array<string> = [];
+      for await (const value of rockPaperScissorsAsync(count)) {
+        values.push(value);
+      }
+      expect(values.length).toBe(count);
+      values.forEach((value) => {
+        expect(ROCK_PAPER_SCISSORS_VALUES).toContain(value);
+      });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForInfiniteAsync(),
+])(
+  'Random Rock Paper Scissors Infinite (async)',
+  (takeCount) => {
+    it('', async () => {
+      const values: Array<string> = [];
+      for await (const value of rockPaperScissorsAsync()) {
+        values.push(value);
+        if (values.length === takeCount) break;
+      }
+      expect(values.length).toBe(takeCount);
+      values.forEach((value) => {
+        expect(ROCK_PAPER_SCISSORS_VALUES).toContain(value);
+      });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForNegativeAsync(),
+])(
+  'Random Rock Paper Scissors Negative (async)',
+  (negativeCount) => {
+    it('', async () => {
+      const gen = rockPaperScissorsAsync(negativeCount);
+      await expect((async () => {
+        for await (const _ of gen) {}
+      })()).rejects.toThrow(InvalidArgumentError);
+    });
+  }
+);
+
+function dataProviderForFiniteSync(): Array<[number]> {
+  return [
+    [0],
+    [1],
+    [5],
+    [10],
+  ];
+}
+
+function dataProviderForInfiniteSync(): Array<[number]> {
+  return [
+    [5],
+    [8],
+  ];
+}
+
+function dataProviderForNegativeSync(): Array<[number]> {
+  return [
+    [-1],
+    [-5],
+  ];
+}
+
+function dataProviderForFiniteAsync(): Array<[number]> {
+  return [
+    [0],
+    [1],
+    [5],
+    [10],
+  ];
+}
+
+function dataProviderForInfiniteAsync(): Array<[number]> {
+  return [
+    [5],
+    [8],
+  ];
+}
+
+function dataProviderForNegativeAsync(): Array<[number]> {
+  return [
+    [-1],
+    [-5],
+  ];
+}

--- a/tests/stream/random.test.ts
+++ b/tests/stream/random.test.ts
@@ -2,6 +2,8 @@ import { percentage } from '../../src/random';
 import { InvalidArgumentError } from '../../src/exceptions';
 import { Stream } from '../../src/stream';
 
+const ROCK_PAPER_SCISSORS_VALUES = ['rock', 'paper', 'scissors'];
+
 describe.each([
   ...dataProviderForFinite(),
 ])(
@@ -70,6 +72,32 @@ describe.each([
         expect(num).toBeGreaterThanOrEqual(0);
         expect(num).toBeLessThan(1);
       });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForStreamWrapper(),
+])(
+  'Stream.ofRockPaperScissors()',
+  (count) => {
+    it('', () => {
+      const values = Stream.ofRockPaperScissors(count).toArray();
+      expect(values.length).toBe(count);
+      values.forEach((value) => {
+        expect(ROCK_PAPER_SCISSORS_VALUES).toContain(value);
+      });
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForNegative(),
+])(
+  'Stream.ofRockPaperScissors() negative',
+  (negativeCount) => {
+    it('', () => {
+      expect(() => Stream.ofRockPaperScissors(negativeCount).toArray()).toThrow(InvalidArgumentError);
     });
   }
 );


### PR DESCRIPTION
Adds random rock-paper-scissors iteration helpers.

Changes:
- Add `random.rockPaperScissors()` and `random.rockPaperScissorsAsync()`
- Add `Stream.ofRockPaperScissors()` and `AsyncStream.ofRockPaperScissors()`
- Add coverage for finite, infinite, invalid repetition, stream, and async usage
- Document the new helpers in the README

Closes #81