### PR TITLE
Implement summary.notAllMatch() and stream APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Quick Reference
 | [`isSorted`](#is-sorted)                | True if iterable sorted                                 | `summary.isSorted(data)`               | `summary.isSortedAsync(data)`               |
 | [`isString`](#is-string)                | True if given data is string                            | `summary.isString(data)`               | `summary.isStringAsync(data)`               |
 | [`noneMatch`](#none-match)              | True if none of items true according to predicate       | `summary.noneMatch(data, predicate)`   | `summary.noneMatchAsync(data, predicate)`   |
+| [`notAllMatch`](#not-all-match)          | True if at least one item is false according to predicate | `summary.notAllMatch(data, predicate)` | `summary.notAllMatchAsync(data, predicate)` |
 | [`same`](#same)                         | True if collections are the same                        | `summary.same(...collections)`         | `summary.sameAsync(...collections)`         |
 | [`sameCount`](#same-count)              | True if collections have the same lengths               | `summary.sameCount(...collections)`    | `summary.sameCountAsync(...collections)`    |
 
@@ -354,6 +355,7 @@ Quick Reference
 | [`isReversed`](#is-reversed-1)      | Returns true if stream is sorted in reverse descending order           | `stream.isReversed()`                  |
 | [`isSorted`](#is-sorted-1)          | Returns true if stream is sorted in ascending order                    | `stream.isSorted()`                    |
 | [`noneMatch`](#none-match-1)        | Returns true if none of the items in stream match predicate            | `stream.noneMatch(predicate)`          |
+| [`notAllMatch`](#not-all-match-1)    | Returns true if at least one item in stream does not match predicate   | `stream.notAllMatch(predicate)`        |
 | [`sameWith`](#same-with)            | Returns true if stream and all given collections are the same          | `stream.sameWith(...collections)`      |
 | [`sameCountWith`](#same-count-with) | Returns true if stream and all given collections have the same lengths | `stream.sameCountWith(...collections)` |
 
@@ -2130,6 +2132,28 @@ const grades         = [45, 50, 61, 0];
 const isPassingGrade = (grade) => grade >= 70;
 
 const trueResult = summary.noneMatch(grades, isPassingGrade);
+// true
+```
+
+### Not All Match
+Returns true if at least one element does not match the predicate function.
+
+```
+function notAllMatch<T>(
+  data: Iterable<T> | Iterator<T>,
+  predicate: (item: T) => boolean
+): boolean
+```
+
+Empty collections return false.
+
+```typescript
+import { summary } from "itertools-ts";
+
+const grades         = [80, 75, 61];
+const isPassingGrade = (grade) => grade >= 70;
+
+const result = summary.notAllMatch(grades, isPassingGrade);
 // true
 ```
 
@@ -3954,6 +3978,26 @@ const isPassingGrade = (grade) => grade >= 70;
 
 const trueResult = Stream.of(grades)
   .noneMatch(isPassingGrade);
+// true
+```
+
+##### Not All Match
+Returns true if at least one element of stream does not match the predicate function.
+
+```
+Stream<T>.notAllMatch(predicate: (item: T) => boolean): boolean
+```
+
+For empty stream returns false.
+
+```typescript
+import { Stream } from "itertools-ts";
+
+const grades         = [80, 75, 61];
+const isPassingGrade = (grade) => grade >= 70;
+
+const result = Stream.of(grades)
+  .notAllMatch(isPassingGrade);
 // true
 ```
 

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -1014,6 +1014,21 @@ export class AsyncStream<T> implements AsyncIterable<T> {
   }
 
   /**
+   * Returns true if at least one element of stream does not match the predicate function.
+   *
+   * For empty stream returns false.
+   *
+   * @param predicate
+   *
+   * @see summary.notAllMatchAsync
+   */
+  async notAllMatch(
+    predicate: (item: T) => Promise<boolean> | boolean
+  ): Promise<boolean> {
+    return await summary.notAllMatchAsync(this, predicate);
+  }
+
+  /**
    * Returns true if stream collection and all given collections are the same.
    *
    * For empty collections list returns true.

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -936,6 +936,19 @@ export class Stream<T> implements Iterable<T> {
   }
 
   /**
+   * Returns true if at least one element of stream does not match the predicate function.
+   *
+   * For empty stream returns false.
+   *
+   * @param predicate
+   *
+   * @see summary.notAllMatch
+   */
+  notAllMatch(predicate: (item: T) => boolean): boolean {
+    return summary.notAllMatch(this, predicate);
+  }
+
+  /**
    * Returns true if stream collection and all given collections are the same.
    *
    * For empty collections list returns true.

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -422,6 +422,36 @@ export async function noneMatchAsync<T>(
 }
 
 /**
+ * Returns true if at least one element does not match the predicate function.
+ *
+ * Empty collections return false.
+ *
+ * @param data
+ * @param predicate
+ */
+export function notAllMatch<T>(
+  data: Iterable<T> | Iterator<T>,
+  predicate: (item: T) => boolean
+): boolean {
+  return !allMatch(data, predicate);
+}
+
+/**
+ * Returns true if at least one element in async collection does not match the predicate function.
+ *
+ * Empty collections return false.
+ *
+ * @param data
+ * @param predicate
+ */
+export async function notAllMatchAsync<T>(
+  data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+  predicate: (item: T) => Promise<boolean> | boolean
+): Promise<boolean> {
+  return !(await allMatchAsync(data, predicate));
+}
+
+/**
  * Returns true if all given collections are the same.
  *
  * For single collection or empty collections list returns true.

--- a/tests/async-stream/summary.test.ts
+++ b/tests/async-stream/summary.test.ts
@@ -11,6 +11,30 @@ import {
   // @ts-ignore
 } from "../fixture";
 
+describe("AsyncStream Not All Match Test", () => {
+  it("returns false for an empty stream", async () => {
+    expect(
+      await AsyncStream.of<number>([]).notAllMatch(async () => false)
+    ).toBeFalsy();
+  });
+
+  it("returns false when all elements match", async () => {
+    expect(
+      await AsyncStream.of([2, 4, 6]).notAllMatch(
+        async (item) => item % 2 === 0
+      )
+    ).toBeFalsy();
+  });
+
+  it("returns true when at least one element does not match", async () => {
+    expect(
+      await AsyncStream.of(createAsyncGeneratorFixture([2, 3, 4])).notAllMatch(
+        async (item) => item % 2 === 0
+      )
+    ).toBeTruthy();
+  });
+});
+
 describe.each([
   ...dataProviderForAsyncGeneratorsTrue(),
   ...dataProviderForAsyncIterablesTrue(),

--- a/tests/stream/summary.test.ts
+++ b/tests/stream/summary.test.ts
@@ -2,6 +2,24 @@
 import { createGeneratorFixture, createIterableFixture, createIteratorFixture, createMapFixture } from "../fixture";
 import { Numeric, Stream } from "../../src";
 
+describe("Stream Not All Match Test", () => {
+  it("returns false for an empty stream", () => {
+    expect(Stream.of<number>([]).notAllMatch(() => false)).toBeFalsy();
+  });
+
+  it("returns false when all elements match", () => {
+    expect(
+      Stream.of([2, 4, 6]).notAllMatch((item) => item % 2 === 0)
+    ).toBeFalsy();
+  });
+
+  it("returns true when at least one element does not match", () => {
+    expect(
+      Stream.of([2, 3, 4]).notAllMatch((item) => item % 2 === 0)
+    ).toBeTruthy();
+  });
+});
+
 describe.each([
   ...dataProviderForArraysTrue(),
   ...dataProviderForGeneratorsTrue(),

--- a/tests/summary/not-all-match.test.ts
+++ b/tests/summary/not-all-match.test.ts
@@ -1,0 +1,139 @@
+import {
+  createAsyncGeneratorFixture,
+  createAsyncIterableFixture,
+  createAsyncIteratorFixture,
+  createGeneratorFixture,
+  createIterableFixture,
+  createIteratorFixture,
+  createMapFixture,
+} from "../fixture";
+import { summary } from "../../src";
+
+type SyncInput = Iterable<number> | Iterator<number>;
+type AsyncInput =
+  | AsyncIterable<number>
+  | AsyncIterator<number>
+  | Iterable<number>
+  | Iterator<number>;
+
+const syncInputFactories: Array<[string, (data: number[]) => SyncInput]> = [
+  ["array", (data) => data],
+  ["generator", createGeneratorFixture],
+  ["iterable", createIterableFixture],
+  ["iterator", createIteratorFixture],
+  ["set", (data) => new Set(data)],
+];
+
+const asyncInputFactories: Array<[string, (data: number[]) => AsyncInput]> = [
+  ["async generator", createAsyncGeneratorFixture],
+  ["async iterable", createAsyncIterableFixture],
+  ["async iterator", createAsyncIteratorFixture],
+  ...syncInputFactories,
+];
+
+describe.each(syncInputFactories)(
+  "Summary Not All Match Test with %s",
+  (_, createInput) => {
+    it("returns false for an empty collection", () => {
+      expect(summary.notAllMatch(createInput([]), () => false)).toBeFalsy();
+    });
+
+    it("returns false when all elements match", () => {
+      expect(
+        summary.notAllMatch(createInput([2, 4, 6]), (item) => item % 2 === 0),
+      ).toBeFalsy();
+    });
+
+    it("returns true when at least one element does not match", () => {
+      expect(
+        summary.notAllMatch(createInput([2, 3, 4]), (item) => item % 2 === 0),
+      ).toBeTruthy();
+    });
+
+    it("returns true when no elements match", () => {
+      expect(
+        summary.notAllMatch(createInput([1, 3, 5]), (item) => item % 2 === 0),
+      ).toBeTruthy();
+    });
+  },
+);
+
+describe.each(asyncInputFactories)(
+  "Summary Not All Match Async Test with %s",
+  (_, createInput) => {
+    it("returns false for an empty collection", async () => {
+      expect(
+        await summary.notAllMatchAsync(createInput([]), async () => false),
+      ).toBeFalsy();
+    });
+
+    it("returns false when all elements match", async () => {
+      expect(
+        await summary.notAllMatchAsync(
+          createInput([2, 4, 6]),
+          async (item) => item % 2 === 0,
+        ),
+      ).toBeFalsy();
+    });
+
+    it("returns true when at least one element does not match", async () => {
+      expect(
+        await summary.notAllMatchAsync(
+          createInput([2, 3, 4]),
+          async (item) => item % 2 === 0,
+        ),
+      ).toBeTruthy();
+    });
+
+    it("returns true when no elements match", async () => {
+      expect(
+        await summary.notAllMatchAsync(
+          createInput([1, 3, 5]),
+          async (item) => item % 2 === 0,
+        ),
+      ).toBeTruthy();
+    });
+  },
+);
+
+it("supports strings", () => {
+  expect(
+    summary.notAllMatch("ABCd", (item) => item.toUpperCase() === item),
+  ).toBeTruthy();
+});
+
+it("supports maps", () => {
+  expect(
+    summary.notAllMatch(
+      createMapFixture([2, 3, 4]),
+      ([, item]) => item % 2 === 0,
+    ),
+  ).toBeTruthy();
+});
+
+it("stops evaluating after the first element that does not match", () => {
+  let calls = 0;
+
+  const result = summary.notAllMatch([2, 3, 4], (item) => {
+    calls++;
+    return item % 2 === 0;
+  });
+
+  expect(result).toBeTruthy();
+  expect(calls).toBe(2);
+});
+
+it("stops async evaluation after the first element that does not match", async () => {
+  let calls = 0;
+
+  const result = await summary.notAllMatchAsync(
+    createAsyncGeneratorFixture([2, 3, 4]),
+    async (item) => {
+      calls++;
+      return item % 2 === 0;
+    },
+  );
+
+  expect(result).toBeTruthy();
+  expect(calls).toBe(2);
+});


### PR DESCRIPTION
## Summary

- add `notAllMatch()` to the synchronous summary API
- add the asynchronous implementation
- add `Stream` and `AsyncStream` wrappers
- add tests for matching, non-matching, empty and short-circuit cases

Closes #68