### PR TITLE
Implement transform.distribute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Quick Reference
 | Iterator                                | Description                             | Sync Code Snippet                 | Async Code Snippet                |
 |-----------------------------------------|-----------------------------------------|-----------------------------------|-----------------------------------|
 | [`divide`](#divide)                     | Divides iterable into n chunks          | `transform.divide(data, n)`       | `transform.divideAsync(data, n)`  |
+| [`distribute`](#distribute)             | Distributes iterable across n groups    | `transform.distribute(data, n)`   | `transform.distributeAsync(data, n)` |
 | [`tee`](#tee)                           | Iterate duplicate iterables             | `transform.tee(data, count)`      | `transform.teeAsync(data, count)` |
 | [`toArray`](#to-array)                  | Transforms collection to array          | `transform.toArray(data)`         | `transform.toArrayAsync(data)`    |
 | [`toAsyncIterable`](#to-async-iterable) | Transforms collection to async iterable | `transform.toAsyncIterable(data)` | —                                 |
@@ -287,6 +288,7 @@ Quick Reference
 | [`compress`](#compress-1)                               | Compress source by filtering out data not selected                                        | `stream.compress(selectors)`                                         |
 | [`distinct`](#distinct-1)                               | Filter out elements: iterate only unique items                                            | `stream.distinct()`                                                  |
 | [`divide`](#divide-1)                                   | Splits stream into n chunks                                                               | `stream.divide(n)`                                                   |
+| [`distribute`](#distribute-1)                           | Distributes stream across n groups                                                        | `stream.distribute(n)`                                               |
 | [`dropWhile`](#drop-while-1)                            | Drop elements from the iterable source while the predicate function is true               | `stream.dropWhile(predicate)`                                        |
 | [`enumerate`](#enumerate-1)                             | Enumerates elements of stream                                                             | `stream.enumerate()`                                                 |
 | [`filter`](#filter-1)                                   | Filter for only elements where the predicate function is true                             | `stream.filter(predicate)`                                           |
@@ -2210,6 +2212,26 @@ const result2 = Array.from(transform.divide(data, 3));
 // [[1, 2], [3, 4], [5]]
 ```
 
+### Distribute
+Distributes the elements of an iterable evenly across n arrays in round-robin order.
+
+```
+function* distribute<T>(
+  data: Iterable<T> | Iterator<T>,
+  n: number
+): Iterable<Array<T>>
+```
+
+* `n` must be a positive finite integer.
+* Throws `InvalidArgumentError` if `n` is invalid.
+
+```typescript
+import { transform } from "itertools-ts";
+
+const result = Array.from(transform.distribute([1, 2, 3, 4, 5], 2));
+// [[1, 3, 5], [2, 4]]
+```
+
 ### Tee
 Return several independent (duplicated) iterators from a single iterable.
 
@@ -2904,6 +2926,22 @@ const result2 = Stream.of(data)
   .divide(3)
   .toArray();
 // [[1, 2], [3, 4], [5]]
+```
+
+#### Distribute
+Distributes the stream across n arrays in round-robin order.
+
+```
+Stream<T>.distribute(n: number): Stream<Array<T>>
+```
+
+```typescript
+import { Stream } from "itertools-ts";
+
+const result = Stream.of([1, 2, 3, 4, 5])
+  .distribute(2)
+  .toArray();
+// [[1, 3, 5], [2, 4]]
 ```
 
 #### Intersection With

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -1094,6 +1094,10 @@ export class AsyncStream<T> implements AsyncIterable<T> {
     return new AsyncStream(dividedIterable);
   }
 
+  distribute(n: number): AsyncStream<Array<T>> {
+    return new AsyncStream(transform.distributeAsync(this.data, n));
+  }
+
   /**
    * Converts stream to Array.
    *

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1000,6 +1000,10 @@ export class Stream<T> implements Iterable<T> {
     return new Stream(dividedIterable); // wrap into stream
   }
 
+  distribute(n: number): Stream<Array<T>> {
+    return new Stream(transform.distribute(this.data, n));
+  }
+
   /**
    * Converts stream to Array.
    *

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -351,3 +351,56 @@ export async function* divideAsync<T>(
   }
 }
 
+export function* distribute<T>(
+  data: Iterable<T> | Iterator<T>,
+  n: number
+): Iterable<Array<T>> {
+  if (
+    typeof n !== "number" ||
+    !Number.isFinite(n) ||
+    n <= 0 ||
+    !Number.isInteger(n)
+  ) {
+    throw new InvalidArgumentError(
+      "distribute: n must be a positive finite integer"
+    );
+  }
+
+  const buckets: Array<Array<T>> = Array.from({ length: n }, () => []);
+  let index = 0;
+
+  for (const item of toIterable(data)) {
+    buckets[index % n].push(item);
+    index += 1;
+  }
+
+  yield* buckets;
+}
+
+export async function* distributeAsync<T>(
+  data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+  n: number
+): AsyncIterable<Array<T>> {
+  if (
+    typeof n !== "number" ||
+    !Number.isFinite(n) ||
+    n <= 0 ||
+    !Number.isInteger(n)
+  ) {
+    throw new InvalidArgumentError(
+      "distribute: n must be a positive finite integer"
+    );
+  }
+
+  const buckets: Array<Array<T>> = Array.from({ length: n }, () => []);
+  let index = 0;
+
+  for await (const item of toAsyncIterable(data)) {
+    buckets[index % n].push(item);
+    index += 1;
+  }
+
+  for (const bucket of buckets) {
+    yield bucket;
+  }
+}

--- a/tests/transform/distribute.test.ts
+++ b/tests/transform/distribute.test.ts
@@ -1,0 +1,110 @@
+import {
+  createAsyncGeneratorFixture,
+  createAsyncIterableFixture,
+  createAsyncIteratorFixture,
+  createGeneratorFixture,
+  createIterableFixture,
+  createIteratorFixture,
+} from "../fixture";
+import { AsyncStream, InvalidArgumentError, Stream, transform } from "../../src";
+
+describe.each(syncDataProvider())(
+  "transform.distribute",
+  (input, n, expected) => {
+    it(`distributes input into ${n} groups`, () => {
+      expect(Array.from(transform.distribute(input, n))).toEqual(expected);
+    });
+  }
+);
+
+describe.each(asyncDataProvider())(
+  "transform.distributeAsync",
+  (input, n, expected) => {
+    it(`distributes input into ${n} groups`, async () => {
+      expect(
+        await transform.toArrayAsync(transform.distributeAsync(input, n))
+      ).toEqual(expected);
+    });
+  }
+);
+
+describe("stream distribute methods", () => {
+  it("distributes a Stream", () => {
+    expect(Stream.of([1, 2, 3, 4, 5]).distribute(3).toArray()).toEqual([
+      [1, 4],
+      [2, 5],
+      [3],
+    ]);
+  });
+
+  it("distributes an AsyncStream", async () => {
+    expect(
+      await AsyncStream.of([1, 2, 3, 4, 5]).distribute(3).toArray()
+    ).toEqual([[1, 4], [2, 5], [3]]);
+  });
+});
+
+it.each([0, -1, 1.5, NaN, Infinity, "2", true])(
+  "rejects invalid group count %s",
+  (n) => {
+    expect(() =>
+      Array.from(transform.distribute([], n as number))
+    ).toThrow(InvalidArgumentError);
+  }
+);
+
+it.each([0, -1, 1.5, NaN, Infinity, "2", true])(
+  "rejects invalid async group count %s",
+  async (n) => {
+    await expect(
+      transform.toArrayAsync(transform.distributeAsync([], n as number))
+    ).rejects.toThrow(InvalidArgumentError);
+  }
+);
+
+function syncDataProvider(): Array<
+  [Iterable<unknown> | Iterator<unknown>, number, Array<Array<unknown>>]
+> {
+  return [
+    [[], 2, [[], []]],
+    [[1, 2, 3, 4], 2, [[1, 3], [2, 4]]],
+    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
+    [[1, 2], 4, [[1], [2], [], []]],
+    ["abcde", 2, [["a", "c", "e"], ["b", "d"]]],
+    [new Set([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+    [
+      new Map([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]),
+      2,
+      [
+        [
+          ["a", 1],
+          ["c", 3],
+        ],
+        [["b", 2]],
+      ],
+    ],
+    [createGeneratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+    [createIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+    [createIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+  ];
+}
+
+function asyncDataProvider(): Array<
+  [
+    AsyncIterable<unknown> | AsyncIterator<unknown> | Iterable<unknown> | Iterator<unknown>,
+    number,
+    Array<Array<unknown>>
+  ]
+> {
+  return [
+    [[], 2, [[], []]],
+    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
+    [createAsyncGeneratorFixture([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+    [createAsyncIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+    [createAsyncIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+  ];
+}

--- a/tests/transform/distribute.test.ts
+++ b/tests/transform/distribute.test.ts
@@ -17,7 +17,7 @@ describe.each(syncDataProvider())(
   }
 );
 
-describe.each(asyncDataProvider())(
+describe.each([...syncDataProvider(), ...asyncDataProvider()])(
   "transform.distributeAsync",
   (input, n, expected) => {
     it(`distributes input into ${n} groups`, async () => {
@@ -101,8 +101,6 @@ function asyncDataProvider(): Array<
   ]
 > {
   return [
-    [[], 2, [[], []]],
-    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
     [createAsyncGeneratorFixture([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
     [createAsyncIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
     [createAsyncIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],


### PR DESCRIPTION
Adds the sync and async distribute transforms plus `Stream` and `AsyncStream` methods. The result always contains `n` round-robin buckets, including empty buckets when needed.

Includes tests and README examples.

Tests: `npm test -- --runInBand`; `npm run build`

Fixes #74