### PR TITLE
Ready fo release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # IterTools Typescript Change Log
 
+## v2.7.0 - 2026-08-06
+
+### New features
+* summary
+  * `isPartitioned()`
+  * `isPartitionedAsync()`
+  * `notAllMatch()`
+  * `notAllMatchAsync()`
+* transform
+  * `distribute()`
+  * `distributeAsync()`
+* Stream
+  * `isPartitioned()`
+  * `notAllMatch()`
+  * `distribute()`
+* AsyncStream
+  * `isPartitioned()`
+  * `notAllMatch()`
+  * `distribute()`
+
+### Improvements
+* `reduce.toAverage()` / `toAverageAsync()` optimized (removed `toValue` overhead)
+* `reduce.toMax()` / `toMaxAsync()` optimized (single-pass, cached comparison)
+* `reduce.toMin()` / `toMinAsync()` optimized (single-pass, cached comparison)
+* `reduce.toMinMax()` / `toMinMaxAsync()` optimized (single-pass, cached comparison)
+* `reduce.toSum()` / `toSumAsync()` optimized (removed `toValue` overhead)
+* `reduce.toProduct()` / `toProductAsync()` optimized (removed `toValue` overhead)
+* `reduce.toCount()` / `toCountAsync()` optimized (removed `toValue` overhead)
+* `combinatorics.cartesianProduct()` / `cartesianProductAsync()` optimized (lazy generation, memory-efficient)
+* `transform.toMap()` / `toMapAsync()` optimized (direct Map constructor)
+* `transform.toSet()` optimized (direct Set constructor)
+* `single.flatten()` / `flattenAsync()` optimized (Map check cached)
+
+### Typing fixes
+* `peek()` callback parameter type fixed from `unknown` to `T` in Stream and AsyncStream
+
 ## v2.6.0 - 2026-07-10
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Quick Reference
 | [`isSorted`](#is-sorted)                | True if iterable sorted                                 | `summary.isSorted(data)`               | `summary.isSortedAsync(data)`               |
 | [`isString`](#is-string)                | True if given data is string                            | `summary.isString(data)`               | `summary.isStringAsync(data)`               |
 | [`noneMatch`](#none-match)              | True if none of items true according to predicate       | `summary.noneMatch(data, predicate)`   | `summary.noneMatchAsync(data, predicate)`   |
+| [`notAllMatch`](#not-all-match)          | True if at least one item is false according to predicate | `summary.notAllMatch(data, predicate)` | `summary.notAllMatchAsync(data, predicate)` |
 | [`same`](#same)                         | True if collections are the same                        | `summary.same(...collections)`         | `summary.sameAsync(...collections)`         |
 | [`sameCount`](#same-count)              | True if collections have the same lengths               | `summary.sameCount(...collections)`    | `summary.sameCountAsync(...collections)`    |
 
@@ -354,6 +355,7 @@ Quick Reference
 | [`isReversed`](#is-reversed-1)      | Returns true if stream is sorted in reverse descending order           | `stream.isReversed()`                  |
 | [`isSorted`](#is-sorted-1)          | Returns true if stream is sorted in ascending order                    | `stream.isSorted()`                    |
 | [`noneMatch`](#none-match-1)        | Returns true if none of the items in stream match predicate            | `stream.noneMatch(predicate)`          |
+| [`notAllMatch`](#not-all-match-1)    | Returns true if at least one item in stream does not match predicate   | `stream.notAllMatch(predicate)`        |
 | [`sameWith`](#same-with)            | Returns true if stream and all given collections are the same          | `stream.sameWith(...collections)`      |
 | [`sameCountWith`](#same-count-with) | Returns true if stream and all given collections have the same lengths | `stream.sameCountWith(...collections)` |
 
@@ -2130,6 +2132,28 @@ const grades         = [45, 50, 61, 0];
 const isPassingGrade = (grade) => grade >= 70;
 
 const trueResult = summary.noneMatch(grades, isPassingGrade);
+// true
+```
+
+### Not All Match
+Returns true if at least one element does not match the predicate function.
+
+```
+function notAllMatch<T>(
+  data: Iterable<T> | Iterator<T>,
+  predicate: (item: T) => boolean
+): boolean
+```
+
+Empty collections return false.
+
+```typescript
+import { summary } from "itertools-ts";
+
+const grades         = [80, 75, 61];
+const isPassingGrade = (grade) => grade >= 70;
+
+const result = summary.notAllMatch(grades, isPassingGrade);
 // true
 ```
 
@@ -3954,6 +3978,26 @@ const isPassingGrade = (grade) => grade >= 70;
 
 const trueResult = Stream.of(grades)
   .noneMatch(isPassingGrade);
+// true
+```
+
+##### Not All Match
+Returns true if at least one element of stream does not match the predicate function.
+
+```
+Stream<T>.notAllMatch(predicate: (item: T) => boolean): boolean
+```
+
+For empty stream returns false.
+
+```typescript
+import { Stream } from "itertools-ts";
+
+const grades         = [80, 75, 61];
+const isPassingGrade = (grade) => grade >= 70;
+
+const result = Stream.of(grades)
+  .notAllMatch(isPassingGrade);
 // true
 ```
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Quick Reference
 | Iterator                                | Description                             | Sync Code Snippet                 | Async Code Snippet                |
 |-----------------------------------------|-----------------------------------------|-----------------------------------|-----------------------------------|
 | [`divide`](#divide)                     | Divides iterable into n chunks          | `transform.divide(data, n)`       | `transform.divideAsync(data, n)`  |
+| [`distribute`](#distribute)             | Distributes iterable across n groups    | `transform.distribute(data, n)`   | `transform.distributeAsync(data, n)` |
 | [`tee`](#tee)                           | Iterate duplicate iterables             | `transform.tee(data, count)`      | `transform.teeAsync(data, count)` |
 | [`toArray`](#to-array)                  | Transforms collection to array          | `transform.toArray(data)`         | `transform.toArrayAsync(data)`    |
 | [`toAsyncIterable`](#to-async-iterable) | Transforms collection to async iterable | `transform.toAsyncIterable(data)` | —                                 |
@@ -287,6 +288,7 @@ Quick Reference
 | [`compress`](#compress-1)                               | Compress source by filtering out data not selected                                        | `stream.compress(selectors)`                                         |
 | [`distinct`](#distinct-1)                               | Filter out elements: iterate only unique items                                            | `stream.distinct()`                                                  |
 | [`divide`](#divide-1)                                   | Splits stream into n chunks                                                               | `stream.divide(n)`                                                   |
+| [`distribute`](#distribute-1)                           | Distributes stream across n groups                                                        | `stream.distribute(n)`                                               |
 | [`dropWhile`](#drop-while-1)                            | Drop elements from the iterable source while the predicate function is true               | `stream.dropWhile(predicate)`                                        |
 | [`enumerate`](#enumerate-1)                             | Enumerates elements of stream                                                             | `stream.enumerate()`                                                 |
 | [`filter`](#filter-1)                                   | Filter for only elements where the predicate function is true                             | `stream.filter(predicate)`                                           |
@@ -2210,6 +2212,26 @@ const result2 = Array.from(transform.divide(data, 3));
 // [[1, 2], [3, 4], [5]]
 ```
 
+### Distribute
+Distributes the elements of an iterable evenly across n arrays in round-robin order.
+
+```
+function* distribute<T>(
+  data: Iterable<T> | Iterator<T>,
+  n: number
+): Iterable<Array<T>>
+```
+
+* `n` must be a positive finite integer.
+* Throws `InvalidArgumentError` if `n` is invalid.
+
+```typescript
+import { transform } from "itertools-ts";
+
+const result = Array.from(transform.distribute([1, 2, 3, 4, 5], 2));
+// [[1, 3, 5], [2, 4]]
+```
+
 ### Tee
 Return several independent (duplicated) iterators from a single iterable.
 
@@ -2904,6 +2926,22 @@ const result2 = Stream.of(data)
   .divide(3)
   .toArray();
 // [[1, 2], [3, 4], [5]]
+```
+
+#### Distribute
+Distributes the stream across n arrays in round-robin order.
+
+```
+Stream<T>.distribute(n: number): Stream<Array<T>>
+```
+
+```typescript
+import { Stream } from "itertools-ts";
+
+const result = Stream.of([1, 2, 3, 4, 5])
+  .distribute(2)
+  .toArray();
+// [[1, 3, 5], [2, 4]]
 ```
 
 #### Intersection With

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Quick Reference
 | [`isEmpty`](#is-empty)                  | True if iterable is empty                               | `summary.isEmpty(data)`                | `summary.isEmptyAsync(data)`                |
 | [`isIterable`](#is-iterable)            | True if given data is iterable                          | `summary.isIterable(data)`             | —                                           |
 | [`isIterator`](#is-iterator)            | True if given data is iterator                          | `summary.isIterator(data)`             | —                                           |
+| [`isPartitioned`](#is-partitioned)      | True if iterable is partitioned according to predicate | `summary.isPartitioned(data, predicate)` | `summary.isPartitionedAsync(data, predicate)` |
 | [`isReversed`](#is-reversed)            | True if iterable reverse sorted                         | `summary.isReversed(data)`             | `summary.isReversedAsync(data)`             |
 | [`isSorted`](#is-sorted)                | True if iterable sorted                                 | `summary.isSorted(data)`               | `summary.isSortedAsync(data)`               |
 | [`isString`](#is-string)                | True if given data is string                            | `summary.isString(data)`               | `summary.isStringAsync(data)`               |
@@ -351,6 +352,7 @@ Quick Reference
 | [`anyMatch`](#any-match-1)          | Returns true if any item in stream matches predicate                   | `stream.anyMatch(predicate)`           |
 | [`exactlyN`](#exactly-n-1)          | Returns true if exactly n items are true according to predicate        | `stream.exactlyN(n, predicate)`        |
 | [`isEmpty`](#is-empty-1)            | Returns true if stream is empty                                        | `stream.isEmpty()`                     |
+| [`isPartitioned`](#is-partitioned-1) | Returns true if stream is partitioned according to predicate          | `stream.isPartitioned(predicate)`      |
 | [`isReversed`](#is-reversed-1)      | Returns true if stream is sorted in reverse descending order           | `stream.isReversed()`                  |
 | [`isSorted`](#is-sorted-1)          | Returns true if stream is sorted in ascending order                    | `stream.isSorted()`                    |
 | [`noneMatch`](#none-match-1)        | Returns true if none of the items in stream match predicate            | `stream.noneMatch(predicate)`          |
@@ -2021,6 +2023,30 @@ const input = [1, 2, 3, 4, 5];
 summary.isIterator(input[Symbol.iterator]()) // true
 summary.isIterator(input); // false
 summary.isIterator(1); // false
+```
+
+### Is Partitioned
+Returns true if all elements that satisfy the predicate appear before all
+elements that don't.
+
+```
+function isPartitioned<T>(
+  data: Iterable<T> | Iterator<T>,
+  predicate?: (item: T) => boolean
+): boolean
+```
+
+- The default predicate is the boolean value of each item.
+- Returns true if empty or has only one element.
+
+```typescript
+import { summary } from "itertools-ts";
+
+summary.isPartitioned([2, 4, 1, 3], (item) => item % 2 === 0);
+// true
+
+summary.isPartitioned([2, 1, 4, 3], (item) => item % 2 === 0);
+// false
 ```
 
 ### Is Reversed
@@ -3907,6 +3933,30 @@ const input = [1];
 
 Stream.of(isEmpty)
   .isEmpty();
+// false
+```
+
+##### Is Partitioned
+Returns true if all elements that satisfy the predicate appear before all
+elements that don't.
+
+```
+Stream<T>.isPartitioned(predicate?: (item: T) => boolean): boolean
+```
+
+The default predicate is the boolean value of each item.
+
+Returns true if iterable source is empty or has only one element.
+
+```typescript
+import { Stream } from "itertools-ts";
+
+Stream.of([2, 4, 1, 3])
+  .isPartitioned((item) => item % 2 === 0);
+// true
+
+Stream.of([2, 1, 4, 3])
+  .isPartitioned((item) => item % 2 === 0);
 // false
 ```
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@smoren/itertools-ts",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "exports": "./src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,14 @@
     {
       "name": "Akash chauhan",
       "url": "https://github.com/Akashrana1001"
+    },
+    {
+      "name": "Mirko Mei",
+      "url": "https://github.com/Ulbrec87"
+    },
+    {
+      "name": "Guflly",
+      "url": "https://github.com/Guflly"
     }
   ],
   "jsnext:main": "./es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itertools-ts",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Extended itertools port for TypeScript and JavaScript. Provides a huge set of functions for working with iterable collections (including async ones)",
   "license": "MIT",
   "repository": {

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -973,6 +973,24 @@ export class AsyncStream<T> implements AsyncIterable<T> {
   }
 
   /**
+   * Returns true if all elements of stream that satisfy the predicate appear
+   * before all elements that don't.
+   *
+   * Returns true if stream is empty or has only one element.
+   *
+   * Default predicate if not provided is the boolean value of each data item.
+   *
+   * @param predicate
+   *
+   * @see summary.isPartitionedAsync
+   */
+  async isPartitioned(
+    predicate?: (item: T) => Promise<boolean> | boolean
+  ): Promise<boolean> {
+    return await summary.isPartitionedAsync(this, predicate);
+  }
+
+  /**
    * Returns true if stream is sorted in ascending order; otherwise false.
    *
    * Items of stream source must be comparable.

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -1014,6 +1014,21 @@ export class AsyncStream<T> implements AsyncIterable<T> {
   }
 
   /**
+   * Returns true if at least one element of stream does not match the predicate function.
+   *
+   * For empty stream returns false.
+   *
+   * @param predicate
+   *
+   * @see summary.notAllMatchAsync
+   */
+  async notAllMatch(
+    predicate: (item: T) => Promise<boolean> | boolean
+  ): Promise<boolean> {
+    return await summary.notAllMatchAsync(this, predicate);
+  }
+
+  /**
    * Returns true if stream collection and all given collections are the same.
    *
    * For empty collections list returns true.

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -731,7 +731,7 @@ export class AsyncStream<T> implements AsyncIterable<T> {
    *
    * @param callback
    */
-  peek(callback: (datum: unknown) => void): AsyncStream<T> {
+  peek(callback: (datum: T) => void): AsyncStream<T> {
     const [data, peekable] = transform.teeAsync(this.data, 2);
     this.data = data;
 

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -1094,6 +1094,10 @@ export class AsyncStream<T> implements AsyncIterable<T> {
     return new AsyncStream(dividedIterable);
   }
 
+  distribute(n: number): AsyncStream<Array<T>> {
+    return new AsyncStream(transform.distributeAsync(this.data, n));
+  }
+
   /**
    * Converts stream to Array.
    *

--- a/src/async-stream.ts
+++ b/src/async-stream.ts
@@ -1127,6 +1127,19 @@ export class AsyncStream<T> implements AsyncIterable<T> {
     return new AsyncStream(dividedIterable);
   }
 
+  /**
+   * Distributes the async stream across n arrays in round-robin order.
+   *
+   * Example:
+   * const s = new AsyncStream([1, 2, 3, 4, 5]);
+   * // Output:
+   * // [1, 3, 5]
+   * // [2, 4]
+   *
+   * @param n The number of groups to distribute the stream into
+   *
+   * @see transform.distributeAsync
+   */
   distribute(n: number): AsyncStream<Array<T>> {
     return new AsyncStream(transform.distributeAsync(this.data, n));
   }

--- a/src/combinatorics.ts
+++ b/src/combinatorics.ts
@@ -6,6 +6,10 @@ import { InvalidArgumentError } from "./exceptions";
 /**
  * Iterates cartesian product of given iterables.
  *
+ * Each input iterable is materialized into an array internally (as repeated
+ * iteration is required), but the product itself is generated lazily one
+ * tuple at a time.
+ *
  * @param iterables
  */
 export function* cartesianProduct<
@@ -22,20 +26,38 @@ export function* cartesianProduct<
     return;
   }
 
-  const arrays = toArray(map(iterables, (iterable) => toArray(iterable)));
-  const toIterate = arrays.reduce(
-    (acc, set) =>
-      acc.flatMap((x) => set.map((y) => [...(x as Array<unknown>), y])),
-    [[]]
-  );
+  const pools = toArray(map(iterables, (iterable) => toArray(iterable)));
 
-  for (const item of toIterate) {
-    yield item as ZipTuple<T, never>;
+  if (pools.some((pool) => pool.length === 0)) {
+    return;
+  }
+
+  const indices = new Array(pools.length).fill(0);
+
+  while (true) {
+    yield pools.map((pool, i) => pool[indices[i]]) as ZipTuple<T, never>;
+
+    let i = pools.length - 1;
+    while (i >= 0) {
+      indices[i]++;
+      if (indices[i] < pools[i].length) {
+        break;
+      }
+      indices[i] = 0;
+      i--;
+    }
+    if (i < 0) {
+      break;
+    }
   }
 }
 
 /**
  * Iterates cartesian product of given async iterables.
+ *
+ * Each input iterable is materialized into an array internally (as repeated
+ * iteration is required), but the product itself is generated lazily one
+ * tuple at a time.
  *
  * @param iterables
  */
@@ -58,18 +80,31 @@ export async function* cartesianProductAsync<
     return;
   }
 
-  const arrays = await toArrayAsync(
+  const pools = await toArrayAsync(
     mapAsync(iterables, async (iterable) => await toArrayAsync(iterable))
   );
 
-  const toIterate = arrays.reduce(
-    (acc, set) =>
-      acc.flatMap((x) => set.map((y) => [...(x as Array<unknown>), y])),
-    [[]]
-  );
+  if (pools.some((pool) => pool.length === 0)) {
+    return;
+  }
 
-  for (const item of toIterate) {
-    yield item as ZipTuple<T, never>;
+  const indices = new Array(pools.length).fill(0);
+
+  while (true) {
+    yield pools.map((pool, i) => pool[indices[i]]) as ZipTuple<T, never>;
+
+    let i = pools.length - 1;
+    while (i >= 0) {
+      indices[i]++;
+      if (indices[i] < pools[i].length) {
+        break;
+      }
+      indices[i] = 0;
+      i--;
+    }
+    if (i < 0) {
+      break;
+    }
   }
 }
 

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -61,14 +61,13 @@ export async function toValueAsync<TInput, TOutput>(
 export function toAverage(
   data: Iterable<number> | Iterator<number>
 ): number | undefined {
-  const [count, sum] = toValue(
-    data,
-    (carry, datum) => {
-      const [count, sum] = carry as [number, number];
-      return [count + 1, sum + Number(datum)];
-    },
-    [0, 0]
-  ) as [number, number];
+  let count = 0;
+  let sum = 0;
+
+  for (const datum of toIterable(data)) {
+    count++;
+    sum += Number(datum);
+  }
 
   return count ? sum / count : undefined;
 }
@@ -87,14 +86,13 @@ export async function toAverageAsync(
     | Iterable<number>
     | Iterator<number>
 ): Promise<number | undefined> {
-  const [count, sum] = (await toValueAsync(
-    data,
-    (carry, datum) => {
-      const [count, sum] = carry as [number, number];
-      return [count + 1, sum + Number(datum)];
-    },
-    [0, 0]
-  )) as [number, number];
+  let count = 0;
+  let sum = 0;
+
+  for await (const datum of toAsyncIterable(data)) {
+    count++;
+    sum += Number(datum);
+  }
 
   return count ? sum / count : undefined;
 }
@@ -114,18 +112,25 @@ export function toMax<TValue>(
   data: Iterable<TValue> | Iterator<TValue>,
   compareBy?: (datum: TValue) => Comparable
 ): TValue | undefined {
+  let result: TValue | undefined;
+
   if (compareBy !== undefined) {
-    return toValue(data, (carry: TValue | undefined, datum) =>
-      compareBy(datum) > compareBy(carry ?? datum) ? datum : carry ?? datum
-    );
+    let resultComparable: Comparable | undefined;
+    for (const datum of toIterable(data)) {
+      const comparable = compareBy(datum);
+      if (resultComparable === undefined || comparable > resultComparable) {
+        result = datum;
+        resultComparable = comparable;
+      }
+    }
+    return result;
   }
 
-  return toValue(data, (carry, datum) => {
-    const lhs = carry ?? datum;
-    const rhs = datum;
-
-    return lhs >= rhs ? lhs : rhs;
-  });
+  for (const datum of toIterable(data)) {
+    const lhs = result ?? datum;
+    result = lhs >= datum ? lhs : datum;
+  }
+  return result;
 }
 
 /**
@@ -147,20 +152,25 @@ export async function toMaxAsync<TValue>(
     | Iterator<TValue>,
   compareBy?: (datum: TValue) => Promise<Comparable> | Comparable
 ): Promise<TValue | undefined> {
+  let result: TValue | undefined;
+
   if (compareBy !== undefined) {
-    return await toValueAsync(data, async (carry: TValue | undefined, datum) =>
-      (await compareBy(datum)) > (await compareBy(carry ?? datum))
-        ? datum
-        : carry ?? datum
-    );
+    let resultComparable: Comparable | undefined;
+    for await (const datum of toAsyncIterable(data)) {
+      const comparable = await compareBy(datum);
+      if (resultComparable === undefined || comparable > resultComparable) {
+        result = datum;
+        resultComparable = comparable;
+      }
+    }
+    return result;
   }
 
-  return await toValueAsync(data, (carry, datum) => {
-    const lhs = carry ?? datum;
-    const rhs = datum;
-
-    return lhs >= rhs ? lhs : rhs;
-  });
+  for await (const datum of toAsyncIterable(data)) {
+    const lhs = result ?? datum;
+    result = lhs >= datum ? lhs : datum;
+  }
+  return result;
 }
 
 /**
@@ -178,18 +188,25 @@ export function toMin<TValue>(
   data: Iterable<TValue> | Iterator<TValue>,
   compareBy?: (datum: TValue) => Comparable
 ): TValue | undefined {
+  let result: TValue | undefined;
+
   if (compareBy !== undefined) {
-    return toValue(data, (carry: TValue | undefined, datum) =>
-      compareBy(datum) < compareBy(carry ?? datum) ? datum : carry ?? datum
-    );
+    let resultComparable: Comparable | undefined;
+    for (const datum of toIterable(data)) {
+      const comparable = compareBy(datum);
+      if (resultComparable === undefined || comparable < resultComparable) {
+        result = datum;
+        resultComparable = comparable;
+      }
+    }
+    return result;
   }
 
-  return toValue(data, (carry, datum) => {
-    const lhs = carry ?? datum;
-    const rhs = datum;
-
-    return lhs <= rhs ? lhs : rhs;
-  });
+  for (const datum of toIterable(data)) {
+    const lhs = result ?? datum;
+    result = lhs <= datum ? lhs : datum;
+  }
+  return result;
 }
 
 /**
@@ -211,20 +228,25 @@ export async function toMinAsync<TValue>(
     | Iterator<TValue>,
   compareBy?: (datum: TValue) => Promise<Comparable> | Comparable
 ): Promise<TValue | undefined> {
+  let result: TValue | undefined;
+
   if (compareBy !== undefined) {
-    return await toValueAsync(data, async (carry: TValue | undefined, datum) =>
-      (await compareBy(datum)) < (await compareBy(carry ?? datum))
-        ? datum
-        : carry ?? datum
-    );
+    let resultComparable: Comparable | undefined;
+    for await (const datum of toAsyncIterable(data)) {
+      const comparable = await compareBy(datum);
+      if (resultComparable === undefined || comparable < resultComparable) {
+        result = datum;
+        resultComparable = comparable;
+      }
+    }
+    return result;
   }
 
-  return await toValueAsync(data, (carry, datum) => {
-    const lhs = carry ?? datum;
-    const rhs = datum;
-
-    return lhs <= rhs ? lhs : rhs;
-  });
+  for await (const datum of toAsyncIterable(data)) {
+    const lhs = result ?? datum;
+    result = lhs <= datum ? lhs : datum;
+  }
+  return result;
 }
 
 /**
@@ -248,21 +270,24 @@ export function toMinMax<T>(
       ? (compareBy as (item: T) => Comparable)
       : (item: T) => item as Comparable;
 
-  return toValue(
-    data,
-    (carry, datum) => {
-      carry = carry as [T?, T?];
-      return [
-        comparableGetter(datum) <= comparableGetter(carry[0] ?? datum)
-          ? datum
-          : carry[0] ?? datum,
-        comparableGetter(datum) >= comparableGetter(carry[1] ?? datum)
-          ? datum
-          : carry[1] ?? datum,
-      ];
-    },
-    [undefined, undefined] as [T?, T?]
-  ) as [T?, T?];
+  let min: T | undefined;
+  let max: T | undefined;
+  let minComparable: Comparable | undefined;
+  let maxComparable: Comparable | undefined;
+
+  for (const datum of toIterable(data)) {
+    const comparable = comparableGetter(datum);
+    if (minComparable === undefined || comparable <= minComparable) {
+      min = datum;
+      minComparable = comparable;
+    }
+    if (maxComparable === undefined || comparable >= maxComparable) {
+      max = datum;
+      maxComparable = comparable;
+    }
+  }
+
+  return [min, max];
 }
 
 /**
@@ -286,23 +311,24 @@ export async function toMinMaxAsync<T>(
       ? (compareBy as (item: T) => Promise<Comparable> | Comparable)
       : (item: T) => item as Comparable;
 
-  return (await toValueAsync(
-    data,
-    async (carry, datum) => {
-      carry = carry as [T?, T?];
-      return [
-        (await comparableGetter(datum)) <=
-        (await comparableGetter(carry[0] ?? datum))
-          ? datum
-          : carry[0] ?? datum,
-        (await comparableGetter(datum)) >=
-        (await comparableGetter(carry[1] ?? datum))
-          ? datum
-          : carry[1] ?? datum,
-      ];
-    },
-    [undefined, undefined] as [T?, T?]
-  )) as [T?, T?];
+  let min: T | undefined;
+  let max: T | undefined;
+  let minComparable: Comparable | undefined;
+  let maxComparable: Comparable | undefined;
+
+  for await (const datum of toAsyncIterable(data)) {
+    const comparable = await comparableGetter(datum);
+    if (minComparable === undefined || comparable <= minComparable) {
+      min = datum;
+      minComparable = comparable;
+    }
+    if (maxComparable === undefined || comparable >= maxComparable) {
+      max = datum;
+      maxComparable = comparable;
+    }
+  }
+
+  return [min, max];
 }
 
 /**
@@ -343,11 +369,11 @@ export async function toRangeAsync(
  * @param data
  */
 export function toSum(data: Iterable<number> | Iterator<number>): number {
-  return toValue(
-    data,
-    (carry, datum) => (carry as number) + Number(datum),
-    0
-  ) as number;
+  let sum = 0;
+  for (const datum of toIterable(data)) {
+    sum += Number(datum);
+  }
+  return sum;
 }
 
 /**
@@ -362,11 +388,11 @@ export async function toSumAsync(
     | Iterable<number>
     | Iterator<number>
 ): Promise<number> {
-  return (await toValueAsync(
-    data,
-    (carry, datum) => (carry as number) + Number(datum),
-    0
-  )) as number;
+  let sum = 0;
+  for await (const datum of toAsyncIterable(data)) {
+    sum += Number(datum);
+  }
+  return sum;
 }
 
 /**
@@ -379,7 +405,13 @@ export async function toSumAsync(
 export function toProduct(
   data: Iterable<number> | Iterator<number>
 ): number | undefined {
-  return toValue(data, (carry, datum) => (carry ?? 1) * datum);
+  let result: number | undefined;
+
+  for (const datum of toIterable(data)) {
+    result = (result ?? 1) * datum;
+  }
+
+  return result;
 }
 
 /**
@@ -396,7 +428,13 @@ export async function toProductAsync(
     | Iterable<number>
     | Iterator<number>
 ): Promise<number | undefined> {
-  return await toValueAsync(data, (carry, datum) => (carry ?? 1) * datum);
+  let result: number | undefined;
+
+  for await (const datum of toAsyncIterable(data)) {
+    result = (result ?? 1) * datum;
+  }
+
+  return result;
 }
 
 /**
@@ -416,7 +454,11 @@ export function toCount(data: Iterable<unknown> | Iterator<unknown>): number {
       return (data as Map<unknown, unknown>).size;
   }
 
-  return toValue(data, (carry) => (carry as number) + 1, 0) as number;
+  let count = 0;
+  for (const _ of toIterable(data)) {
+    count++;
+  }
+  return count;
 }
 
 /**
@@ -439,11 +481,11 @@ export async function toCountAsync(
       return toCount(data as Iterable<unknown>);
   }
 
-  return (await toValueAsync(
-    data,
-    (carry) => (carry as number) + 1,
-    0
-  )) as number;
+  let count = 0;
+  for await (const _ of toAsyncIterable(data)) {
+    count++;
+  }
+  return count;
 }
 
 /**

--- a/src/single.ts
+++ b/src/single.ts
@@ -302,9 +302,11 @@ export function* flatten(
   data: Iterable<unknown> | Iterator<unknown>,
   dimensions = Infinity
 ): Iterable<unknown> {
+  const isMap = data instanceof Map;
+
   if (dimensions < 1) {
     for (let datum of toIterable(data)) {
-      if (data instanceof Map) {
+      if (isMap) {
         datum = (datum as [unknown, unknown])[1];
       }
 
@@ -314,7 +316,7 @@ export function* flatten(
   }
 
   for (let datum of toIterable(data)) {
-    if (data instanceof Map) {
+    if (isMap) {
       datum = (datum as [unknown, unknown])[1];
     }
 
@@ -347,9 +349,11 @@ export async function* flattenAsync(
     | Iterator<unknown>,
   dimensions = Infinity
 ): AsyncIterable<unknown> {
+  const isMap = data instanceof Map;
+
   if (dimensions < 1) {
     for await (let datum of toAsyncIterable(data)) {
-      if (data instanceof Map) {
+      if (isMap) {
         datum = (datum as [unknown, unknown])[1];
       }
 
@@ -359,7 +363,7 @@ export async function* flattenAsync(
   }
 
   for await (let datum of toAsyncIterable(data)) {
-    if (data instanceof Map) {
+    if (isMap) {
       datum = (datum as [unknown, unknown])[1];
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1000,6 +1000,10 @@ export class Stream<T> implements Iterable<T> {
     return new Stream(dividedIterable); // wrap into stream
   }
 
+  distribute(n: number): Stream<Array<T>> {
+    return new Stream(transform.distribute(this.data, n));
+  }
+
   /**
    * Converts stream to Array.
    *

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1029,6 +1029,19 @@ export class Stream<T> implements Iterable<T> {
     return new Stream(dividedIterable); // wrap into stream
   }
 
+  /**
+   * Distributes the stream across n arrays in round-robin order.
+   *
+   * Example:
+   * const s = new Stream([1, 2, 3, 4, 5]);
+   * // Output:
+   * // [1, 3, 5]
+   * // [2, 4]
+   *
+   * @param n The number of groups to distribute the stream into
+   *
+   * @see transform.distribute
+   */
   distribute(n: number): Stream<Array<T>> {
     return new Stream(transform.distribute(this.data, n));
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -659,7 +659,7 @@ export class Stream<T> implements Iterable<T> {
    *
    * @param callback
    */
-  peek(callback: (datum: unknown) => void): Stream<T> {
+  peek(callback: (datum: T) => void): Stream<T> {
     const [data, peekable] = transform.tee(this.data, 2);
     this.data = data;
 
@@ -1031,9 +1031,9 @@ export class Stream<T> implements Iterable<T> {
 
   /**
    * Generates random elements from the given collection.
-   * 
+   *
    * If optional param `repetitions` is not given, iterates infinitely.
-   * 
+   *
    * @param repetitions - Number of values to generate
    * @throws InvalidArgumentError if repetitions is negative
    * @throws LengthError if stream is empty.

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -936,6 +936,19 @@ export class Stream<T> implements Iterable<T> {
   }
 
   /**
+   * Returns true if at least one element of stream does not match the predicate function.
+   *
+   * For empty stream returns false.
+   *
+   * @param predicate
+   *
+   * @see summary.notAllMatch
+   */
+  notAllMatch(predicate: (item: T) => boolean): boolean {
+    return summary.notAllMatch(this, predicate);
+  }
+
+  /**
    * Returns true if stream collection and all given collections are the same.
    *
    * For empty collections list returns true.

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -897,6 +897,22 @@ export class Stream<T> implements Iterable<T> {
   }
 
   /**
+   * Returns true if all elements of stream that satisfy the predicate appear
+   * before all elements that don't.
+   *
+   * Returns true if stream is empty or has only one element.
+   *
+   * Default predicate if not provided is the boolean value of each data item.
+   *
+   * @param predicate
+   *
+   * @see summary.isPartitioned
+   */
+  isPartitioned(predicate?: (item: T) => boolean): boolean {
+    return summary.isPartitioned(this, predicate);
+  }
+
+  /**
    * Returns true if stream is sorted in ascending order; otherwise false.
    *
    * Items of stream source must be comparable.

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -285,6 +285,74 @@ export function isIterator(input: unknown): boolean {
 }
 
 /**
+ * Returns true if all elements of given collection that satisfy the predicate
+ * appear before all elements that don't.
+ *
+ * Returns true if given collection is empty or has only one element.
+ *
+ * Default predicate if not provided is the boolean value of each data item.
+ *
+ * @param data
+ * @param predicate
+ */
+export function isPartitioned<T>(
+  data: Iterable<T> | Iterator<T>,
+  predicate?: (item: T) => boolean
+): boolean {
+  if (predicate === undefined) {
+    predicate = (datum) => Boolean(datum);
+  }
+
+  let falseItemFound = false;
+  for (const datum of toIterable(data)) {
+    const matches = predicate(datum);
+
+    if (falseItemFound && matches) {
+      return false;
+    }
+
+    if (!matches) {
+      falseItemFound = true;
+    }
+  }
+  return true;
+}
+
+/**
+ * Returns true if all elements of given async collection that satisfy the
+ * predicate appear before all elements that don't.
+ *
+ * Returns true if given collection is empty or has only one element.
+ *
+ * Default predicate if not provided is the boolean value of each data item.
+ *
+ * @param data
+ * @param predicate
+ */
+export async function isPartitionedAsync<T>(
+  data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+  predicate?: (item: T) => Promise<boolean> | boolean
+): Promise<boolean> {
+  if (predicate === undefined) {
+    predicate = (datum) => Boolean(datum);
+  }
+
+  let falseItemFound = false;
+  for await (const datum of toAsyncIterable(data)) {
+    const matches = await predicate(datum);
+
+    if (falseItemFound && matches) {
+      return false;
+    }
+
+    if (!matches) {
+      falseItemFound = true;
+    }
+  }
+  return true;
+}
+
+/**
  * Returns true if given collection is sorted in descending order; otherwise false.
  *
  * Items of given collection must be comparable.

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -422,6 +422,36 @@ export async function noneMatchAsync<T>(
 }
 
 /**
+ * Returns true if at least one element does not match the predicate function.
+ *
+ * Empty collections return false.
+ *
+ * @param data
+ * @param predicate
+ */
+export function notAllMatch<T>(
+  data: Iterable<T> | Iterator<T>,
+  predicate: (item: T) => boolean
+): boolean {
+  return !allMatch(data, predicate);
+}
+
+/**
+ * Returns true if at least one element in async collection does not match the predicate function.
+ *
+ * Empty collections return false.
+ *
+ * @param data
+ * @param predicate
+ */
+export async function notAllMatchAsync<T>(
+  data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+  predicate: (item: T) => Promise<boolean> | boolean
+): Promise<boolean> {
+  return !(await allMatchAsync(data, predicate));
+}
+
+/**
  * Returns true if all given collections are the same.
  *
  * For single collection or empty collections list returns true.

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -351,6 +351,14 @@ export async function* divideAsync<T>(
   }
 }
 
+/**
+ * Distributes the elements of the iterable across n arrays in round-robin order.
+ *
+ * Example: ([1, 2, 3, 4, 5], 2) => [1, 3, 5], [2, 4]
+ *
+ * @param data
+ * @param n
+ */
 export function* distribute<T>(
   data: Iterable<T> | Iterator<T>,
   n: number
@@ -377,6 +385,14 @@ export function* distribute<T>(
   yield* buckets;
 }
 
+/**
+ * Distributes the elements of the async iterable across n arrays in round-robin order.
+ *
+ * Example: ([1, 2, 3, 4, 5], 2) => [1, 3, 5], [2, 4]
+ *
+ * @param data
+ * @param n
+ */
 export async function* distributeAsync<T>(
   data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
   n: number

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -351,3 +351,56 @@ export async function* divideAsync<T>(
   }
 }
 
+export function* distribute<T>(
+  data: Iterable<T> | Iterator<T>,
+  n: number
+): Iterable<Array<T>> {
+  if (
+    typeof n !== "number" ||
+    !Number.isFinite(n) ||
+    n <= 0 ||
+    !Number.isInteger(n)
+  ) {
+    throw new InvalidArgumentError(
+      "distribute: n must be a positive finite integer"
+    );
+  }
+
+  const buckets: Array<Array<T>> = Array.from({ length: n }, () => []);
+  let index = 0;
+
+  for (const item of toIterable(data)) {
+    buckets[index % n].push(item);
+    index += 1;
+  }
+
+  yield* buckets;
+}
+
+export async function* distributeAsync<T>(
+  data: AsyncIterable<T> | AsyncIterator<T> | Iterable<T> | Iterator<T>,
+  n: number
+): AsyncIterable<Array<T>> {
+  if (
+    typeof n !== "number" ||
+    !Number.isFinite(n) ||
+    n <= 0 ||
+    !Number.isInteger(n)
+  ) {
+    throw new InvalidArgumentError(
+      "distribute: n must be a positive finite integer"
+    );
+  }
+
+  const buckets: Array<Array<T>> = Array.from({ length: n }, () => []);
+  let index = 0;
+
+  for await (const item of toAsyncIterable(data)) {
+    buckets[index % n].push(item);
+    index += 1;
+  }
+
+  for (const bucket of buckets) {
+    yield bucket;
+  }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -196,11 +196,7 @@ export function toMap<TKey, TValue>(
     | Iterator<[TKey, TValue]>
     | Record<PropertyKey, unknown>
 ): Map<TKey, TValue> {
-  const result: Map<TKey, TValue> = new Map();
-  for (const [key, value] of toIterable(pairs)) {
-    result.set(key, value);
-  }
-  return result;
+  return new Map(toIterable(pairs) as Iterable<[TKey, TValue]>);
 }
 
 /**
@@ -229,11 +225,7 @@ export async function toMapAsync<TKey, TValue>(
  * @param collection
  */
 export function toSet<T>(collection: Iterable<T> | Iterator<T>): Set<T> {
-  const result: Set<T> = new Set();
-  for (const datum of toIterable(collection)) {
-    result.add(datum);
-  }
-  return result;
+  return new Set(toIterable(collection));
 }
 
 /**

--- a/tests/async-stream/summary.test.ts
+++ b/tests/async-stream/summary.test.ts
@@ -11,30 +11,6 @@ import {
   // @ts-ignore
 } from "../fixture";
 
-describe("AsyncStream Not All Match Test", () => {
-  it("returns false for an empty stream", async () => {
-    expect(
-      await AsyncStream.of<number>([]).notAllMatch(async () => false)
-    ).toBeFalsy();
-  });
-
-  it("returns false when all elements match", async () => {
-    expect(
-      await AsyncStream.of([2, 4, 6]).notAllMatch(
-        async (item) => item % 2 === 0
-      )
-    ).toBeFalsy();
-  });
-
-  it("returns true when at least one element does not match", async () => {
-    expect(
-      await AsyncStream.of(createAsyncGeneratorFixture([2, 3, 4])).notAllMatch(
-        async (item) => item % 2 === 0
-      )
-    ).toBeTruthy();
-  });
-});
-
 describe.each([
   ...dataProviderForAsyncGeneratorsTrue(),
   ...dataProviderForAsyncIterablesTrue(),
@@ -205,6 +181,41 @@ function dataProviderForArraysTrue(): Array<[Array<any>, (iterable: Array<any>) 
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      [1],
+      (iterable: Iterable<number> | Iterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number> | Iterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x > 2),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number> | Iterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x < 3),
+    ],
+    [
+      ['a'],
+      (iterable: Iterable<unknown> | Iterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x !== 'a'),
+    ],
+    [
+      ['a', 'B', 'C'],
+      (iterable: Iterable<unknown> | Iterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      ['a', 'B', 'C'],
+      (iterable: Iterable<unknown> | Iterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      ['OS', 'PHP', 'python'],
+      (iterable: Iterable<unknown> | Iterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -339,6 +350,36 @@ function dataProviderForStringsTrue(): Array<[string, (iterable: string) => Prom
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      '1',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x !== '1'),
+    ],
+    [
+      '123',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => Number(x) > 2),
+    ],
+    [
+      '123',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => Number(x) < 3),
+    ],
+    [
+      'a',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x !== 'a'),
+    ],
+    [
+      'aBC',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x.toLowerCase() === x),
+    ],
+    [
+      'aBC',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -469,6 +510,41 @@ function dataProviderForSetsTrue(): Array<[Set<any>, (iterable: Set<any>) => Pro
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      new Set([1]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x > 2),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x < 3),
+    ],
+    [
+      new Set(['a']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x !== 'a'),
+    ],
+    [
+      new Set(['a', 'B', 'C']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      new Set(['a', 'B', 'C']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      new Set(['OS', 'PHP', 'python']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -584,6 +660,41 @@ function dataProviderForMapsTrue(): Array<[Map<any, any>, (iterable: Map<any, an
       (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
         .runningTotal()
         .sameCountWith([11, 22, 33]),
+    ],
+    [
+      createMapFixture([1]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] !== 1),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] > 2),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] < 3),
+    ],
+    [
+      createMapFixture(['a']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] !== 'a'),
+    ],
+    [
+      createMapFixture(['a', 'B', 'C']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1].toLowerCase() === x[1]),
+    ],
+    [
+      createMapFixture(['a', 'B', 'C']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
+    ],
+    [
+      createMapFixture(['OS', 'PHP', 'python']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
     ],
   ];
 }
@@ -722,6 +833,44 @@ function dataProviderForAsyncTrue(): Array<[Array<any>, (iterable: AsyncIterable
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      [1],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch(async (x) => {
+          await asyncTimeout(1);
+          return x > 2;
+        }),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x < 3),
+    ],
+    [
+      ['a'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x !== 'a'),
+    ],
+    [
+      ['a', 'B', 'C'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      ['a', 'B', 'C'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      ['OS', 'PHP', 'python'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -841,6 +990,51 @@ function dataProviderForArraysFalse(): Array<[Array<any>, (iterable: Array<any>)
         .runningTotal()
         .sameCountWith([11, 22]),
     ],
+    [
+      [],
+      (iterable: Iterable<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      [],
+      (iterable: Iterable<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      [1],
+      (iterable: Iterable<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x === 1),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x >= 1),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x < 4),
+    ],
+    [
+      ['a'],
+      (iterable: Iterable<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x === 'a'),
+    ],
+    [
+      ['A', 'B', 'C'],
+      (iterable: Iterable<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      ['a', 'b', 'c'],
+      (iterable: Iterable<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      ['OS', 'PHP', 'COBOL'],
+      (iterable: Iterable<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -954,6 +1148,46 @@ function dataProviderForStringsFalse(): Array<[string, (iterable: string) => Pro
         .runningTotal()
         .sameCountWith([11, 22]),
     ],
+    [
+      '',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      '',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      '1',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x === '1'),
+    ],
+    [
+      '123',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => Number(x) >= 1),
+    ],
+    [
+      '123',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => Number(x) < 4),
+    ],
+    [
+      'a',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x === 'a'),
+    ],
+    [
+      'ABC',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x.toUpperCase() === x),
+    ],
+    [
+      'abc',
+      (iterable) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x.toLowerCase() === x),
+    ],
   ];
 }
 
@@ -1047,6 +1281,51 @@ function dataProviderForSetsFalse(): Array<[Set<any>, (iterable: Set<any>) => Pr
         .runningTotal()
         .sameCountWith([11, 22]),
     ],
+    [
+      new Set([]),
+      (iterable: Set<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      new Set([]),
+      (iterable: Set<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      new Set([1]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x === 1),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x >= 1),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x < 4),
+    ],
+    [
+      new Set(['a']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x === 'a'),
+    ],
+    [
+      new Set(['A', 'B', 'C']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      new Set(['a', 'b', 'c']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      new Set(['OS', 'PHP', 'COBOL']),
+      (iterable: Set<string>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -1136,6 +1415,51 @@ function dataProviderForMapsFalse(): Array<[Map<any, any>, (iterable: Map<any, a
       (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
         .runningTotal()
         .sameCountWith([11, 22]),
+    ],
+    [
+      createMapFixture([]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      createMapFixture([]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      createMapFixture([1]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] === 1),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] >= 1),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] < 4),
+    ],
+    [
+      createMapFixture(['a']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1] === 'a'),
+    ],
+    [
+      createMapFixture(['A', 'B', 'C']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
+    ],
+    [
+      createMapFixture(['a', 'b', 'c']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1].toLowerCase() === x[1]),
+    ],
+    [
+      createMapFixture(['OS', 'PHP', 'COBOL']),
+      (iterable: Map<unknown, string>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
     ],
   ];
 }
@@ -1246,6 +1570,54 @@ function dataProviderForAsyncFalse(): Array<[Array<any>, (iterable: AsyncIterabl
       (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
         .runningTotal()
         .sameCountWith([11, 22]),
+    ],
+    [
+      [],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch(async () => {
+          await asyncTimeout(1);
+          return true;
+        }),
+    ],
+    [
+      [],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      [1],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x === 1),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x >= 1),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .notAllMatch((x) => x < 4),
+    ],
+    [
+      ['a'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x === 'a'),
+    ],
+    [
+      ['A', 'B', 'C'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      ['a', 'b', 'c'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      ['OS', 'PHP', 'COBOL'],
+      (iterable: AsyncIterable<unknown> | AsyncIterator<unknown>) => AsyncStream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
     ],
   ];
 }

--- a/tests/async-stream/summary.test.ts
+++ b/tests/async-stream/summary.test.ts
@@ -11,6 +11,30 @@ import {
   // @ts-ignore
 } from "../fixture";
 
+describe("AsyncStream Not All Match Test", () => {
+  it("returns false for an empty stream", async () => {
+    expect(
+      await AsyncStream.of<number>([]).notAllMatch(async () => false)
+    ).toBeFalsy();
+  });
+
+  it("returns false when all elements match", async () => {
+    expect(
+      await AsyncStream.of([2, 4, 6]).notAllMatch(
+        async (item) => item % 2 === 0
+      )
+    ).toBeFalsy();
+  });
+
+  it("returns true when at least one element does not match", async () => {
+    expect(
+      await AsyncStream.of(createAsyncGeneratorFixture([2, 3, 4])).notAllMatch(
+        async (item) => item % 2 === 0
+      )
+    ).toBeTruthy();
+  });
+});
+
 describe.each([
   ...dataProviderForAsyncGeneratorsTrue(),
   ...dataProviderForAsyncIterablesTrue(),

--- a/tests/async-stream/summary.test.ts
+++ b/tests/async-stream/summary.test.ts
@@ -117,6 +117,11 @@ function dataProviderForArraysTrue(): Array<[Array<any>, (iterable: Array<any>) 
         .isEmpty(),
     ],
     [
+      [2, 4, 1, 3],
+      (iterable: Iterable<number> | Iterator<number>) => AsyncStream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       [1, -1, 2, -2, 3, -3],
       (iterable: Iterable<number> | Iterator<number>) => AsyncStream.of(iterable)
         .filter((item) => item > 0)
@@ -241,6 +246,11 @@ function dataProviderForStringsTrue(): Array<[string, (iterable: string) => Prom
       '',
       (iterable) => AsyncStream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      '2413',
+      (iterable) => AsyncStream.of(iterable)
+        .isPartitioned((item) => Number(item) % 2 === 0),
     ],
     [
       '123',
@@ -371,6 +381,11 @@ function dataProviderForSetsTrue(): Array<[Set<any>, (iterable: Set<any>) => Pro
         .isEmpty(),
     ],
     [
+      new Set([2, 4, 1, 3]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       new Set([1, -1, 2, -2, 3, -3]),
       (iterable: Set<number>) => AsyncStream.of(iterable)
         .filter((item) => item > 0)
@@ -477,6 +492,11 @@ function dataProviderForMapsTrue(): Array<[Map<any, any>, (iterable: Map<any, an
       createMapFixture([]),
       (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      createMapFixture([2, 4, 1, 3]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .isPartitioned((item) => item[1] % 2 === 0),
     ],
     [
       createMapFixture([1, -1, 2, -2, 3, -3]),
@@ -608,6 +628,14 @@ function dataProviderForAsyncTrue(): Array<[Array<any>, (iterable: AsyncIterable
         .isEmpty(),
     ],
     [
+      [2, 4, 1, 3],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .isPartitioned(async (item) => {
+          await asyncTimeout(1);
+          return item % 2 === 0;
+        }),
+    ],
+    [
       [1, -1, 2, -2, 3, -3],
       (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
         .filter((item) => item > 0)
@@ -737,6 +765,11 @@ function dataProviderForArraysFalse(): Array<[Array<any>, (iterable: Array<any>)
         .isEmpty(),
     ],
     [
+      [2, 1, 4, 3],
+      (iterable: Iterable<number>) => AsyncStream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       [1, -1, 2, -2, 3, -3],
       (iterable: Iterable<number>) => AsyncStream.of(iterable)
         .runningTotal()
@@ -841,6 +874,11 @@ function dataProviderForStringsFalse(): Array<[string, (iterable: string) => Pro
         .isEmpty(),
     ],
     [
+      '2143',
+      (iterable) => AsyncStream.of(iterable)
+        .isPartitioned((item) => Number(item) % 2 === 0),
+    ],
+    [
       '131',
       (iterable) => AsyncStream.of(iterable)
         .isSorted(),
@@ -933,6 +971,11 @@ function dataProviderForSetsFalse(): Array<[Set<any>, (iterable: Set<any>) => Pr
         .isEmpty(),
     ],
     [
+      new Set([2, 1, 4, 3]),
+      (iterable: Set<number>) => AsyncStream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       new Set([1, -1, 2, -2, 3, -3]),
       (iterable: Set<number>) => AsyncStream.of(iterable)
         .runningTotal()
@@ -1010,6 +1053,11 @@ function dataProviderForMapsFalse(): Array<[Map<any, any>, (iterable: Map<any, a
       createMapFixture([1]),
       (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      createMapFixture([2, 1, 4, 3]),
+      (iterable: Map<unknown, number>) => AsyncStream.of(iterable)
+        .isPartitioned((item) => item[1] % 2 === 0),
     ],
     [
       createMapFixture([1, -1, 2, -2, 3, -3]),
@@ -1115,6 +1163,14 @@ function dataProviderForAsyncFalse(): Array<[Array<any>, (iterable: AsyncIterabl
       [1],
       (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      [2, 1, 4, 3],
+      (iterable: AsyncIterable<number> | AsyncIterator<number>) => AsyncStream.of(iterable)
+        .isPartitioned(async (item) => {
+          await asyncTimeout(1);
+          return item % 2 === 0;
+        }),
     ],
     [
       [1, -1, 2, -2, 3, -3],

--- a/tests/async-stream/transform.test.ts
+++ b/tests/async-stream/transform.test.ts
@@ -78,6 +78,27 @@ describe.each(dataProviderForDivide())(
   }
 );
 
+describe.each(dataProviderForDistribute())(
+  "AsyncStream Transform Distribute Test",
+  (input, count, expected) => {
+    it(`distributes input into ${count} groups`, async () => {
+      // Given
+      const inputStream = AsyncStream.of(input);
+
+      // When
+      const groups = inputStream.distribute(count); // returns AsyncStream<unknown[]>
+
+      const result: any[] = [];
+      for await (const group of groups) {
+        result.push(group); // each group is already an array
+      }
+
+      // Then
+      expect(result).toEqual(expected);
+    });
+  }
+);
+
 
 
 function dataProviderForArrays(): Array<[Array<any>, (data: Array<any>) => any, any]> {
@@ -540,6 +561,44 @@ function dataProviderForDivide(): Array<[any, number, any[]]> {
 
     // Async Iterators
     [createAsyncIteratorFixture([1, 2, 3, 4, 5]), 3, [[1, 2], [3, 4], [5]]],
+  ];
+}
+
+function dataProviderForDistribute(): Array<[any, number, any[]]> {
+  return [
+    // Arrays
+    [[], 2, [[], []]],
+    [[1, 2, 3, 4], 2, [[1, 3], [2, 4]]],
+    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
+    [[1, 2], 4, [[1], [2], [], []]],
+
+    // Strings
+    ['abcde', 2, [['a', 'c', 'e'], ['b', 'd']]],
+
+    // Sets
+    [new Set([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+
+    // Maps (distribute on entries)
+    [new Map([['a', 1], ['b', 2], ['c', 3]]), 2,
+      [[['a', 1], ['c', 3]], [['b', 2]]]],
+
+    // Generators
+    [createGeneratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Iterables
+    [createIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Iterators
+    [createIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Async Generators
+    [createAsyncGeneratorFixture([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+
+    // Async Iterables
+    [createAsyncIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Async Iterators
+    [createAsyncIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
   ];
 }
 

--- a/tests/stream/peek.test.ts
+++ b/tests/stream/peek.test.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { createGeneratorFixture, createIterableFixture, createIteratorFixture, createMapFixture } from "../fixture";
-import { NumericString, Stream } from '../../src';
+import { Stream } from '../../src';
 
 describe.each([
   ...dataProviderForArrays(),

--- a/tests/stream/summary.test.ts
+++ b/tests/stream/summary.test.ts
@@ -103,6 +103,11 @@ function dataProviderForArraysTrue(): Array<[Array<any>, (iterable: Array<any>) 
         .isEmpty(),
     ],
     [
+      [2, 4, 1, 3],
+      (iterable: Iterable<number> | Iterator<number>) => Stream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       [1, -1, 2, -2, 3, -3],
       (iterable: Iterable<number> | Iterator<number>) => Stream.of(iterable)
         .filter((item) => item > 0)
@@ -227,6 +232,11 @@ function dataProviderForStringsTrue(): Array<[string, (iterable: string) => bool
       '',
       (iterable) => Stream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      '2413',
+      (iterable) => Stream.of(iterable)
+        .isPartitioned((item) => Number(item) % 2 === 0),
     ],
     [
       '123',
@@ -357,6 +367,11 @@ function dataProviderForSetsTrue(): Array<[Set<any>, (iterable: Set<any>) => boo
         .isEmpty(),
     ],
     [
+      new Set([2, 4, 1, 3]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       new Set([1, -1, 2, -2, 3, -3]),
       (iterable: Set<number>) => Stream.of(iterable)
         .filter((item) => item > 0)
@@ -463,6 +478,11 @@ function dataProviderForMapsTrue(): Array<[Map<any, any>, (iterable: Map<any, an
       createMapFixture([]),
       (iterable: Map<unknown, number>) => Stream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      createMapFixture([2, 4, 1, 3]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .isPartitioned((item) => item[1] % 2 === 0),
     ],
     [
       createMapFixture([1, -1, 2, -2, 3, -3]),
@@ -573,6 +593,11 @@ function dataProviderForArraysFalse(): Array<[Array<any>, (iterable: Array<any>)
         .isEmpty(),
     ],
     [
+      [2, 1, 4, 3],
+      (iterable: Iterable<number>) => Stream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       [1, -1, 2, -2, 3, -3],
       (iterable: Iterable<number>) => Stream.of(iterable)
         .runningTotal()
@@ -677,6 +702,11 @@ function dataProviderForStringsFalse(): Array<[string, (iterable: string) => boo
         .isEmpty(),
     ],
     [
+      '2143',
+      (iterable) => Stream.of(iterable)
+        .isPartitioned((item) => Number(item) % 2 === 0),
+    ],
+    [
       '131',
       (iterable) => Stream.of(iterable)
         .isSorted(),
@@ -769,6 +799,11 @@ function dataProviderForSetsFalse(): Array<[Set<any>, (iterable: Set<any>) => bo
         .isEmpty(),
     ],
     [
+      new Set([2, 1, 4, 3]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .isPartitioned((item) => item % 2 === 0),
+    ],
+    [
       new Set([1, -1, 2, -2, 3, -3]),
       (iterable: Set<number>) => Stream.of(iterable)
         .runningTotal()
@@ -846,6 +881,11 @@ function dataProviderForMapsFalse(): Array<[Map<any, any>, (iterable: Map<any, a
       createMapFixture([1]),
       (iterable: Map<unknown, number>) => Stream.of(iterable)
         .isEmpty(),
+    ],
+    [
+      createMapFixture([2, 1, 4, 3]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .isPartitioned((item) => item[1] % 2 === 0),
     ],
     [
       createMapFixture([1, -1, 2, -2, 3, -3]),

--- a/tests/stream/summary.test.ts
+++ b/tests/stream/summary.test.ts
@@ -2,6 +2,24 @@
 import { createGeneratorFixture, createIterableFixture, createIteratorFixture, createMapFixture } from "../fixture";
 import { Numeric, Stream } from "../../src";
 
+describe("Stream Not All Match Test", () => {
+  it("returns false for an empty stream", () => {
+    expect(Stream.of<number>([]).notAllMatch(() => false)).toBeFalsy();
+  });
+
+  it("returns false when all elements match", () => {
+    expect(
+      Stream.of([2, 4, 6]).notAllMatch((item) => item % 2 === 0)
+    ).toBeFalsy();
+  });
+
+  it("returns true when at least one element does not match", () => {
+    expect(
+      Stream.of([2, 3, 4]).notAllMatch((item) => item % 2 === 0)
+    ).toBeTruthy();
+  });
+});
+
 describe.each([
   ...dataProviderForArraysTrue(),
   ...dataProviderForGeneratorsTrue(),

--- a/tests/stream/summary.test.ts
+++ b/tests/stream/summary.test.ts
@@ -2,24 +2,6 @@
 import { createGeneratorFixture, createIterableFixture, createIteratorFixture, createMapFixture } from "../fixture";
 import { Numeric, Stream } from "../../src";
 
-describe("Stream Not All Match Test", () => {
-  it("returns false for an empty stream", () => {
-    expect(Stream.of<number>([]).notAllMatch(() => false)).toBeFalsy();
-  });
-
-  it("returns false when all elements match", () => {
-    expect(
-      Stream.of([2, 4, 6]).notAllMatch((item) => item % 2 === 0)
-    ).toBeFalsy();
-  });
-
-  it("returns true when at least one element does not match", () => {
-    expect(
-      Stream.of([2, 3, 4]).notAllMatch((item) => item % 2 === 0)
-    ).toBeTruthy();
-  });
-});
-
 describe.each([
   ...dataProviderForArraysTrue(),
   ...dataProviderForGeneratorsTrue(),
@@ -185,6 +167,41 @@ function dataProviderForArraysTrue(): Array<[Array<any>, (iterable: Array<any>) 
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      [1],
+      (iterable: Iterable<number> | Iterator<number>) => Stream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number> | Iterator<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x > 2),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number> | Iterator<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x < 3),
+    ],
+    [
+      ['a'],
+      (iterable: Iterable<string> | Iterator<string>) => Stream.of(iterable)
+        .notAllMatch((x) => x !== 'a'),
+    ],
+    [
+      ['a', 'B', 'C'],
+      (iterable: Iterable<string> | Iterator<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      ['a', 'B', 'C'],
+      (iterable: Iterable<string> | Iterator<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      ['OS', 'PHP', 'python'],
+      (iterable: Iterable<string> | Iterator<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -319,6 +336,36 @@ function dataProviderForStringsTrue(): Array<[string, (iterable: string) => bool
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      '1',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x !== '1'),
+    ],
+    [
+      '123',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => Number(x) > 2),
+    ],
+    [
+      '123',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => Number(x) < 3),
+    ],
+    [
+      'a',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x !== 'a'),
+    ],
+    [
+      'aBC',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x.toLowerCase() === x),
+    ],
+    [
+      'aBC',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -449,6 +496,41 @@ function dataProviderForSetsTrue(): Array<[Set<any>, (iterable: Set<any>) => boo
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      new Set([1]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x > 2),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x < 3),
+    ],
+    [
+      new Set(['a']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x) => x !== 'a'),
+    ],
+    [
+      new Set(['a', 'B', 'C']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      new Set(['a', 'B', 'C']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      new Set(['OS', 'PHP', 'python']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -565,6 +647,41 @@ function dataProviderForMapsTrue(): Array<[Map<any, any>, (iterable: Map<any, an
         .runningTotal()
         .sameCountWith([11, 22, 33]),
     ],
+    [
+      createMapFixture([1]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] !== 1),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] > 2),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] < 3),
+    ],
+    [
+      createMapFixture(['a']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] !== 'a'),
+    ],
+    [
+      createMapFixture(['a', 'B', 'C']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1].toLowerCase() === x[1]),
+    ],
+    [
+      createMapFixture(['a', 'B', 'C']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
+    ],
+    [
+      createMapFixture(['OS', 'PHP', 'python']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
+    ],
   ];
 }
 
@@ -662,6 +779,51 @@ function dataProviderForArraysFalse(): Array<[Array<any>, (iterable: Array<any>)
       (iterable: Iterable<unknown>) => Stream.of(iterable)
         .runningTotal()
         .sameCountWith([11, 22]),
+    ],
+    [
+      [],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      [],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      [1],
+      (iterable: Iterable<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x === 1),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x >= 1),
+    ],
+    [
+      [1, 2, 3],
+      (iterable: Iterable<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x < 4),
+    ],
+    [
+      ['a'],
+      (iterable: Iterable<unknown>) => Stream.of(iterable)
+        .notAllMatch((x) => x === 'a'),
+    ],
+    [
+      ['A', 'B', 'C'],
+      (iterable: Iterable<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      ['a', 'b', 'c'],
+      (iterable: Iterable<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      ['OS', 'PHP', 'COBOL'],
+      (iterable: Iterable<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
     ],
   ];
 }
@@ -776,6 +938,46 @@ function dataProviderForStringsFalse(): Array<[string, (iterable: string) => boo
         .runningTotal()
         .sameCountWith([11, 22]),
     ],
+    [
+      '',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      '',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      '1',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x === '1'),
+    ],
+    [
+      '123',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => Number(x) >= 1),
+    ],
+    [
+      '123',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => Number(x) < 4),
+    ],
+    [
+      'a',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x === 'a'),
+    ],
+    [
+      'ABC',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x.toUpperCase() === x),
+    ],
+    [
+      'abc',
+      (iterable) => Stream.of(iterable)
+        .notAllMatch((x) => x.toLowerCase() === x),
+    ],
   ];
 }
 
@@ -869,6 +1071,51 @@ function dataProviderForSetsFalse(): Array<[Set<any>, (iterable: Set<any>) => bo
         .runningTotal()
         .sameCountWith([11, 22]),
     ],
+    [
+      new Set([]),
+      (iterable: Set<unknown>) => Stream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      new Set([]),
+      (iterable: Set<unknown>) => Stream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      new Set([1]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x === 1),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x >= 1),
+    ],
+    [
+      new Set([1, 2, 3]),
+      (iterable: Set<number>) => Stream.of(iterable)
+        .notAllMatch((x) => x < 4),
+    ],
+    [
+      new Set(['a']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x) => x === 'a'),
+    ],
+    [
+      new Set(['A', 'B', 'C']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
+    [
+      new Set(['a', 'b', 'c']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toLowerCase() === x),
+    ],
+    [
+      new Set(['OS', 'PHP', 'COBOL']),
+      (iterable: Set<string>) => Stream.of(iterable)
+        .notAllMatch((x: any) => x.toUpperCase() === x),
+    ],
   ];
 }
 
@@ -958,6 +1205,51 @@ function dataProviderForMapsFalse(): Array<[Map<any, any>, (iterable: Map<any, a
       (iterable: Map<unknown, number>) => Stream.of(iterable)
         .runningTotal()
         .sameCountWith([11, 22]),
+    ],
+    [
+      createMapFixture([]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch(() => true),
+    ],
+    [
+      createMapFixture([]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch(() => false),
+    ],
+    [
+      createMapFixture([1]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] === 1),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] >= 1),
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (iterable: Map<unknown, number>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] < 4),
+    ],
+    [
+      createMapFixture(['a']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1] === 'a'),
+    ],
+    [
+      createMapFixture(['A', 'B', 'C']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
+    ],
+    [
+      createMapFixture(['a', 'b', 'c']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1].toLowerCase() === x[1]),
+    ],
+    [
+      createMapFixture(['OS', 'PHP', 'COBOL']),
+      (iterable: Map<unknown, string>) => Stream.of(iterable)
+        .notAllMatch((x) => x[1].toUpperCase() === x[1]),
     ],
   ];
 }

--- a/tests/stream/transform.test.ts
+++ b/tests/stream/transform.test.ts
@@ -70,6 +70,29 @@ describe.each([
   }
 );
 
+describe.each([
+  ...dataProviderForDistribute(),
+])(
+  "Stream Transform Distribute Test",
+  (input, count, expected) => {
+    it(`distributes input into ${count} groups`, () => {
+      // Given
+      const inputStream = Stream.of(input);
+      const result: any[] = [];
+
+      // When
+      const groups = inputStream.distribute(count); // returns Stream<Array>
+
+      for (const group of groups) {
+        result.push(group);
+      }
+
+      // Then
+      expect(result).toEqual(expected);
+    });
+  }
+);
+
 
 
 
@@ -452,6 +475,35 @@ function dataProviderForDivide(): Array<[any, number, any[]]> {
 
     // Iterators
     [createIteratorFixture([1, 2, 3, 4, 5]), 3, [[1, 2], [3, 4], [5]]],
+  ];
+}
+
+function dataProviderForDistribute(): Array<[any, number, any[]]> {
+  return [
+    // Arrays
+    [[], 2, [[], []]],
+    [[1, 2, 3, 4], 2, [[1, 3], [2, 4]]],
+    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
+    [[1, 2], 4, [[1], [2], [], []]],
+
+    // Strings
+    ['abcde', 2, [['a', 'c', 'e'], ['b', 'd']]],
+
+    // Sets
+    [new Set([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+
+    // Maps (distribute on entries)
+    [new Map([['a', 1], ['b', 2], ['c', 3]]), 2,
+      [[['a', 1], ['c', 3]], [['b', 2]]]],
+
+    // Generators
+    [createGeneratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Iterables
+    [createIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Iterators
+    [createIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
   ];
 }
 

--- a/tests/summary/is-partitioned.test.ts
+++ b/tests/summary/is-partitioned.test.ts
@@ -1,0 +1,153 @@
+import {
+  createAsyncGeneratorFixture,
+  createAsyncIterableFixture,
+  createAsyncIteratorFixture,
+  createGeneratorFixture,
+  createIterableFixture,
+  createIteratorFixture,
+  createMapFixture,
+  // @ts-ignore
+} from '../fixture';
+import { summary } from '../../src';
+
+describe.each(dataProviderForTrue())(
+  "Summary Is Partitioned Test True",
+  (input, predicate) => {
+    it("", () => {
+      expect(summary.isPartitioned(input, predicate)).toBeTruthy();
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForTrue(),
+  ...dataProviderForAsyncTrue(),
+])(
+  "Summary Is Partitioned Async Test True",
+  (input, predicate) => {
+    it("", async () => {
+      expect(
+        await summary.isPartitionedAsync(input, predicate)
+      ).toBeTruthy();
+    });
+  }
+);
+
+describe.each(dataProviderForFalse())(
+  "Summary Is Partitioned Test False",
+  (input, predicate) => {
+    it("", () => {
+      expect(summary.isPartitioned(input, predicate)).toBeFalsy();
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForFalse(),
+  ...dataProviderForAsyncFalse(),
+])(
+  "Summary Is Partitioned Async Test False",
+  (input, predicate) => {
+    it("", async () => {
+      expect(
+        await summary.isPartitionedAsync(input, predicate)
+      ).toBeFalsy();
+    });
+  }
+);
+
+it("Summary Is Partitioned Test Short Circuit", () => {
+  const predicate = jest.fn(isEven);
+
+  expect(summary.isPartitioned([2, 1, 4, 6], predicate)).toBeFalsy();
+  expect(predicate).toHaveBeenCalledTimes(3);
+});
+
+it("Summary Is Partitioned Async Test Short Circuit", async () => {
+  const predicate = jest.fn(async (item: number) => isEven(item));
+
+  expect(
+    await summary.isPartitionedAsync([2, 1, 4, 6], predicate)
+  ).toBeFalsy();
+  expect(predicate).toHaveBeenCalledTimes(3);
+});
+
+function dataProviderForTrue(): Array<
+  [
+    Iterable<any> | Iterator<any>,
+    ((item: any) => boolean) | undefined,
+  ]
+> {
+  return [
+    [[], undefined],
+    [[true], undefined],
+    [[true, true, false, false], undefined],
+    [[false, false], undefined],
+    [[2, 4, 1, 3], isEven],
+    [createGeneratorFixture([2, 4, 1, 3]), isEven],
+    [createIterableFixture([2, 4, 1, 3]), isEven],
+    [createIteratorFixture([2, 4, 1, 3]), isEven],
+    ['2413', (item: string) => isEven(Number(item))],
+    [new Set([2, 4, 1, 3]), isEven],
+    [
+      createMapFixture([2, 4, 1, 3]),
+      (item: [number, number]) => isEven(item[1]),
+    ],
+  ];
+}
+
+function dataProviderForAsyncTrue(): Array<
+  [
+    AsyncIterable<any> | AsyncIterator<any>,
+    ((item: any) => Promise<boolean> | boolean) | undefined,
+  ]
+> {
+  return [
+    [createAsyncGeneratorFixture([2, 4, 1, 3]), asyncIsEven],
+    [createAsyncIterableFixture([2, 4, 1, 3]), asyncIsEven],
+    [createAsyncIteratorFixture([2, 4, 1, 3]), asyncIsEven],
+    [createAsyncIterableFixture([true, false]), undefined],
+  ];
+}
+
+function dataProviderForFalse(): Array<
+  [
+    Iterable<any> | Iterator<any>,
+    ((item: any) => boolean) | undefined,
+  ]
+> {
+  return [
+    [[true, false, true], undefined],
+    [[2, 1, 4, 3], isEven],
+    [createGeneratorFixture([2, 1, 4, 3]), isEven],
+    [createIterableFixture([2, 1, 4, 3]), isEven],
+    [createIteratorFixture([2, 1, 4, 3]), isEven],
+    ['2143', (item: string) => isEven(Number(item))],
+    [new Set([2, 1, 4, 3]), isEven],
+    [
+      createMapFixture([2, 1, 4, 3]),
+      (item: [number, number]) => isEven(item[1]),
+    ],
+  ];
+}
+
+function dataProviderForAsyncFalse(): Array<
+  [
+    AsyncIterable<any> | AsyncIterator<any>,
+    (item: any) => Promise<boolean> | boolean,
+  ]
+> {
+  return [
+    [createAsyncGeneratorFixture([2, 1, 4, 3]), asyncIsEven],
+    [createAsyncIterableFixture([2, 1, 4, 3]), asyncIsEven],
+    [createAsyncIteratorFixture([2, 1, 4, 3]), asyncIsEven],
+  ];
+}
+
+function isEven(item: number): boolean {
+  return item % 2 === 0;
+}
+
+async function asyncIsEven(item: number): Promise<boolean> {
+  return isEven(item);
+}

--- a/tests/summary/not-all-match.test.ts
+++ b/tests/summary/not-all-match.test.ts
@@ -1,0 +1,139 @@
+import {
+  createAsyncGeneratorFixture,
+  createAsyncIterableFixture,
+  createAsyncIteratorFixture,
+  createGeneratorFixture,
+  createIterableFixture,
+  createIteratorFixture,
+  createMapFixture,
+} from "../fixture";
+import { summary } from "../../src";
+
+type SyncInput = Iterable<number> | Iterator<number>;
+type AsyncInput =
+  | AsyncIterable<number>
+  | AsyncIterator<number>
+  | Iterable<number>
+  | Iterator<number>;
+
+const syncInputFactories: Array<[string, (data: number[]) => SyncInput]> = [
+  ["array", (data) => data],
+  ["generator", createGeneratorFixture],
+  ["iterable", createIterableFixture],
+  ["iterator", createIteratorFixture],
+  ["set", (data) => new Set(data)],
+];
+
+const asyncInputFactories: Array<[string, (data: number[]) => AsyncInput]> = [
+  ["async generator", createAsyncGeneratorFixture],
+  ["async iterable", createAsyncIterableFixture],
+  ["async iterator", createAsyncIteratorFixture],
+  ...syncInputFactories,
+];
+
+describe.each(syncInputFactories)(
+  "Summary Not All Match Test with %s",
+  (_, createInput) => {
+    it("returns false for an empty collection", () => {
+      expect(summary.notAllMatch(createInput([]), () => false)).toBeFalsy();
+    });
+
+    it("returns false when all elements match", () => {
+      expect(
+        summary.notAllMatch(createInput([2, 4, 6]), (item) => item % 2 === 0),
+      ).toBeFalsy();
+    });
+
+    it("returns true when at least one element does not match", () => {
+      expect(
+        summary.notAllMatch(createInput([2, 3, 4]), (item) => item % 2 === 0),
+      ).toBeTruthy();
+    });
+
+    it("returns true when no elements match", () => {
+      expect(
+        summary.notAllMatch(createInput([1, 3, 5]), (item) => item % 2 === 0),
+      ).toBeTruthy();
+    });
+  },
+);
+
+describe.each(asyncInputFactories)(
+  "Summary Not All Match Async Test with %s",
+  (_, createInput) => {
+    it("returns false for an empty collection", async () => {
+      expect(
+        await summary.notAllMatchAsync(createInput([]), async () => false),
+      ).toBeFalsy();
+    });
+
+    it("returns false when all elements match", async () => {
+      expect(
+        await summary.notAllMatchAsync(
+          createInput([2, 4, 6]),
+          async (item) => item % 2 === 0,
+        ),
+      ).toBeFalsy();
+    });
+
+    it("returns true when at least one element does not match", async () => {
+      expect(
+        await summary.notAllMatchAsync(
+          createInput([2, 3, 4]),
+          async (item) => item % 2 === 0,
+        ),
+      ).toBeTruthy();
+    });
+
+    it("returns true when no elements match", async () => {
+      expect(
+        await summary.notAllMatchAsync(
+          createInput([1, 3, 5]),
+          async (item) => item % 2 === 0,
+        ),
+      ).toBeTruthy();
+    });
+  },
+);
+
+it("supports strings", () => {
+  expect(
+    summary.notAllMatch("ABCd", (item) => item.toUpperCase() === item),
+  ).toBeTruthy();
+});
+
+it("supports maps", () => {
+  expect(
+    summary.notAllMatch(
+      createMapFixture([2, 3, 4]),
+      ([, item]) => item % 2 === 0,
+    ),
+  ).toBeTruthy();
+});
+
+it("stops evaluating after the first element that does not match", () => {
+  let calls = 0;
+
+  const result = summary.notAllMatch([2, 3, 4], (item) => {
+    calls++;
+    return item % 2 === 0;
+  });
+
+  expect(result).toBeTruthy();
+  expect(calls).toBe(2);
+});
+
+it("stops async evaluation after the first element that does not match", async () => {
+  let calls = 0;
+
+  const result = await summary.notAllMatchAsync(
+    createAsyncGeneratorFixture([2, 3, 4]),
+    async (item) => {
+      calls++;
+      return item % 2 === 0;
+    },
+  );
+
+  expect(result).toBeTruthy();
+  expect(calls).toBe(2);
+});

--- a/tests/summary/not-all-match.test.ts
+++ b/tests/summary/not-all-match.test.ts
@@ -5,135 +5,901 @@ import {
   createGeneratorFixture,
   createIterableFixture,
   createIteratorFixture,
-  createMapFixture,
-} from "../fixture";
-import { summary } from "../../src";
+  createMapFixture
+  // @ts-ignore
+} from '../fixture';
+import { summary } from '../../src';
 
-type SyncInput = Iterable<number> | Iterator<number>;
-type AsyncInput =
-  | AsyncIterable<number>
-  | AsyncIterator<number>
-  | Iterable<number>
-  | Iterator<number>;
-
-const syncInputFactories: Array<[string, (data: number[]) => SyncInput]> = [
-  ["array", (data) => data],
-  ["generator", createGeneratorFixture],
-  ["iterable", createIterableFixture],
-  ["iterator", createIteratorFixture],
-  ["set", (data) => new Set(data)],
-];
-
-const asyncInputFactories: Array<[string, (data: number[]) => AsyncInput]> = [
-  ["async generator", createAsyncGeneratorFixture],
-  ["async iterable", createAsyncIterableFixture],
-  ["async iterator", createAsyncIteratorFixture],
-  ...syncInputFactories,
-];
-
-describe.each(syncInputFactories)(
-  "Summary Not All Match Test with %s",
-  (_, createInput) => {
-    it("returns false for an empty collection", () => {
-      expect(summary.notAllMatch(createInput([]), () => false)).toBeFalsy();
+describe.each([
+  ...dataProviderForArraysTrue(),
+  ...dataProviderForGeneratorsTrue(),
+  ...dataProviderForIterablesTrue(),
+  ...dataProviderForIteratorsTrue(),
+  ...dataProviderForStringsTrue(),
+  ...dataProviderForSetsTrue(),
+  ...dataProviderForMapsTrue(),
+])(
+  "Summary Not All Match Test True",
+  (input, predicate) => {
+    it("", () => {
+      expect(summary.notAllMatch(input, predicate)).toBeTruthy();
     });
-
-    it("returns false when all elements match", () => {
-      expect(
-        summary.notAllMatch(createInput([2, 4, 6]), (item) => item % 2 === 0),
-      ).toBeFalsy();
-    });
-
-    it("returns true when at least one element does not match", () => {
-      expect(
-        summary.notAllMatch(createInput([2, 3, 4]), (item) => item % 2 === 0),
-      ).toBeTruthy();
-    });
-
-    it("returns true when no elements match", () => {
-      expect(
-        summary.notAllMatch(createInput([1, 3, 5]), (item) => item % 2 === 0),
-      ).toBeTruthy();
-    });
-  },
+  }
 );
 
-describe.each(asyncInputFactories)(
-  "Summary Not All Match Async Test with %s",
-  (_, createInput) => {
-    it("returns false for an empty collection", async () => {
-      expect(
-        await summary.notAllMatchAsync(createInput([]), async () => false),
-      ).toBeFalsy();
+describe.each([
+  ...dataProviderForAsyncGeneratorsTrue(),
+  ...dataProviderForAsyncIterablesTrue(),
+  ...dataProviderForAsyncIteratorsTrue(),
+  ...dataProviderForArraysTrue(),
+  ...dataProviderForGeneratorsTrue(),
+  ...dataProviderForIterablesTrue(),
+  ...dataProviderForIteratorsTrue(),
+  ...dataProviderForStringsTrue(),
+  ...dataProviderForSetsTrue(),
+  ...dataProviderForMapsTrue(),
+])(
+  "Summary Not All Match Async Test True",
+  (input, predicate) => {
+    it("", async () => {
+      expect(await summary.notAllMatchAsync(input, predicate)).toBeTruthy();
     });
-
-    it("returns false when all elements match", async () => {
-      expect(
-        await summary.notAllMatchAsync(
-          createInput([2, 4, 6]),
-          async (item) => item % 2 === 0,
-        ),
-      ).toBeFalsy();
-    });
-
-    it("returns true when at least one element does not match", async () => {
-      expect(
-        await summary.notAllMatchAsync(
-          createInput([2, 3, 4]),
-          async (item) => item % 2 === 0,
-        ),
-      ).toBeTruthy();
-    });
-
-    it("returns true when no elements match", async () => {
-      expect(
-        await summary.notAllMatchAsync(
-          createInput([1, 3, 5]),
-          async (item) => item % 2 === 0,
-        ),
-      ).toBeTruthy();
-    });
-  },
+  }
 );
 
-it("supports strings", () => {
+describe.each([
+  ...dataProviderForArraysFalse(),
+  ...dataProviderForGeneratorsFalse(),
+  ...dataProviderForIterablesFalse(),
+  ...dataProviderForIteratorsFalse(),
+  ...dataProviderForStringsFalse(),
+  ...dataProviderForSetsFalse(),
+  ...dataProviderForMapsFalse(),
+])(
+  "Summary Not All Match Test False",
+  (input, predicate) => {
+    it("", () => {
+      expect(summary.notAllMatch(input, predicate)).toBeFalsy();
+    });
+  }
+);
+
+describe.each([
+  ...dataProviderForAsyncGeneratorsFalse(),
+  ...dataProviderForAsyncIterablesFalse(),
+  ...dataProviderForAsyncIteratorsFalse(),
+  ...dataProviderForArraysFalse(),
+  ...dataProviderForGeneratorsFalse(),
+  ...dataProviderForIterablesFalse(),
+  ...dataProviderForIteratorsFalse(),
+  ...dataProviderForStringsFalse(),
+  ...dataProviderForSetsFalse(),
+  ...dataProviderForMapsFalse(),
+])(
+  "Summary Not All Match Async Test False",
+  (input, predicate) => {
+    it("", async () => {
+      expect(await summary.notAllMatchAsync(input, predicate)).toBeFalsy();
+    });
+  }
+);
+
+it("Summary Not All Match Test Short Circuit", () => {
+  const predicate = jest.fn((item: number) => item % 2 === 0);
+
+  expect(summary.notAllMatch([2, 3, 4], predicate)).toBeTruthy();
+  expect(predicate).toHaveBeenCalledTimes(2);
+});
+
+it("Summary Not All Match Async Test Short Circuit", async () => {
+  const predicate = jest.fn(async (item: number) => item % 2 === 0);
+
   expect(
-    summary.notAllMatch("ABCd", (item) => item.toUpperCase() === item),
+    await summary.notAllMatchAsync([2, 3, 4], predicate)
   ).toBeTruthy();
+  expect(predicate).toHaveBeenCalledTimes(2);
 });
 
-it("supports maps", () => {
-  expect(
-    summary.notAllMatch(
-      createMapFixture([2, 3, 4]),
-      ([, item]) => item % 2 === 0,
-    ),
-  ).toBeTruthy();
-});
+function dataProviderForArraysTrue(): Array<[Array<any>, (item: any) => boolean]> {
+  return [
+    [
+      [1],
+      () => false,
+    ],
+    [
+      [1, 2, 3],
+      (x: number) => x > 2,
+    ],
+    [
+      [1, 2, 3],
+      (x: number) => x < 3,
+    ],
+    [
+      ['a'],
+      (x: string) => x !== 'a',
+    ],
+    [
+      ['a', 'B', 'C'],
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      ['a', 'B', 'C'],
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      ['OS', 'PHP', 'python'],
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      [[1], ['a', 'b'], [1.1, 2.2, 3.3]],
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
 
-it("stops evaluating after the first element that does not match", () => {
-  let calls = 0;
+function dataProviderForGeneratorsTrue(): Array<[Generator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createGeneratorFixture([1]),
+      () => false,
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      createGeneratorFixture(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      createGeneratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createGeneratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createGeneratorFixture(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createGeneratorFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
 
-  const result = summary.notAllMatch([2, 3, 4], (item) => {
-    calls++;
-    return item % 2 === 0;
-  });
+function dataProviderForIterablesTrue(): Array<[Iterable<any>, (item: any) => boolean]> {
+  return [
+    [
+      createIterableFixture([1]),
+      () => false,
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      createIterableFixture(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      createIterableFixture(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createIterableFixture(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIterableFixture(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIterableFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
 
-  expect(result).toBeTruthy();
-  expect(calls).toBe(2);
-});
+function dataProviderForIteratorsTrue(): Array<[Iterator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createIteratorFixture([1]),
+      () => false,
+    ],
+    [
+      createIteratorFixture([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      createIteratorFixture([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      createIteratorFixture(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      createIteratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createIteratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIteratorFixture(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIteratorFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
 
-it("stops async evaluation after the first element that does not match", async () => {
-  let calls = 0;
+function dataProviderForStringsTrue(): Array<[string, (item: any) => boolean]> {
+  return [
+    [
+      '1',
+      (x: string) => x !== '1',
+    ],
+    [
+      '123',
+      (x: string) => Number(x) > 2,
+    ],
+    [
+      '123',
+      (x: string) => Number(x) < 3,
+    ],
+    [
+      'a',
+      (x: string) => x !== 'a',
+    ],
+    [
+      'aBC',
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      'aBC',
+      (x: string) => x.toUpperCase() === x,
+    ],
+  ];
+}
 
-  const result = await summary.notAllMatchAsync(
-    createAsyncGeneratorFixture([2, 3, 4]),
-    async (item) => {
-      calls++;
-      return item % 2 === 0;
-    },
-  );
+function dataProviderForSetsTrue(): Array<[Set<any>, (item: any) => boolean]> {
+  return [
+    [
+      new Set([1]),
+      () => false,
+    ],
+    [
+      new Set([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      new Set([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      new Set(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      new Set(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      new Set(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      new Set(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      new Set([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
 
-  expect(result).toBeTruthy();
-  expect(calls).toBe(2);
-});
+function dataProviderForMapsTrue(): Array<[Map<any, any>, (item: any) => boolean]> {
+  return [
+    [
+      createMapFixture([1]),
+      (x: [unknown, number]) => x[1] !== 1,
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (x: [unknown, number]) => x[1] > 2,
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (x: [unknown, number]) => x[1] < 3,
+    ],
+    [
+      createMapFixture(['a']),
+      (x: [unknown, string]) => x[1] !== 'a',
+    ],
+    [
+      createMapFixture(['a', 'B', 'C']),
+      (x: [unknown, string]) => x[1].toLowerCase() === x[1],
+    ],
+    [
+      createMapFixture(['a', 'B', 'C']),
+      (x: [unknown, string]) => x[1].toUpperCase() === x[1],
+    ],
+    [
+      createMapFixture(['OS', 'PHP', 'python']),
+      (x: [unknown, string]) => x[1].toUpperCase() === x[1],
+    ],
+    [
+      createMapFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: [unknown, Array<unknown>]) => x[1].length === 3,
+    ],
+  ];
+}
+
+function dataProviderForAsyncGeneratorsTrue(): Array<[AsyncGenerator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createAsyncGeneratorFixture([1]),
+      () => false,
+    ],
+    [
+      createAsyncGeneratorFixture([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      createAsyncGeneratorFixture([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      createAsyncGeneratorFixture(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      createAsyncGeneratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createAsyncGeneratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncGeneratorFixture(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncGeneratorFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForAsyncIterablesTrue(): Array<[AsyncIterable<any>, (item: any) => boolean]> {
+  return [
+    [
+      createAsyncIterableFixture([1]),
+      () => false,
+    ],
+    [
+      createAsyncIterableFixture([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      createAsyncIterableFixture([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      createAsyncIterableFixture(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      createAsyncIterableFixture(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createAsyncIterableFixture(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIterableFixture(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIterableFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForAsyncIteratorsTrue(): Array<[AsyncIterator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createAsyncIteratorFixture([1]),
+      () => false,
+    ],
+    [
+      createAsyncIteratorFixture([1, 2, 3]),
+      (x: number) => x > 2,
+    ],
+    [
+      createAsyncIteratorFixture([1, 2, 3]),
+      (x: number) => x < 3,
+    ],
+    [
+      createAsyncIteratorFixture(['a']),
+      (x: string) => x !== 'a',
+    ],
+    [
+      createAsyncIteratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createAsyncIteratorFixture(['a', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIteratorFixture(['OS', 'PHP', 'python']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIteratorFixture([[1], ['a', 'b'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForArraysFalse(): Array<[Array<any>, (item: any) => boolean]> {
+  return [
+    [
+      [],
+      () => true,
+    ],
+    [
+      [],
+      () => false,
+    ],
+    [
+      [1],
+      (x: number) => x === 1,
+    ],
+    [
+      [1, 2, 3],
+      (x: number) => x >= 1,
+    ],
+    [
+      [1, 2, 3],
+      (x: number) => x < 4,
+    ],
+    [
+      ['a'],
+      (x: string) => x === 'a',
+    ],
+    [
+      ['A', 'B', 'C'],
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      ['a', 'b', 'c'],
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      ['OS', 'PHP', 'COBOL'],
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      [[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]],
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForGeneratorsFalse(): Array<[Generator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createGeneratorFixture([]),
+      () => true,
+    ],
+    [
+      createGeneratorFixture([]),
+      () => false,
+    ],
+    [
+      createGeneratorFixture([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      createGeneratorFixture([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      createGeneratorFixture(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      createGeneratorFixture(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createGeneratorFixture(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createGeneratorFixture(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createGeneratorFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForIterablesFalse(): Array<[Iterable<any>, (item: any) => boolean]> {
+  return [
+    [
+      createIterableFixture([]),
+      () => true,
+    ],
+    [
+      createIterableFixture([]),
+      () => false,
+    ],
+    [
+      createIterableFixture([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      createIterableFixture([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      createIterableFixture(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      createIterableFixture(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIterableFixture(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createIterableFixture(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIterableFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForIteratorsFalse(): Array<[Iterator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createIteratorFixture([]),
+      () => true,
+    ],
+    [
+      createIteratorFixture([]),
+      () => false,
+    ],
+    [
+      createIteratorFixture([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      createIteratorFixture([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      createIteratorFixture([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      createIteratorFixture(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      createIteratorFixture(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIteratorFixture(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createIteratorFixture(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createIteratorFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForStringsFalse(): Array<[string, (item: any) => boolean]> {
+  return [
+    [
+      '',
+      () => true,
+    ],
+    [
+      '',
+      () => false,
+    ],
+    [
+      '1',
+      (x: string) => x === '1',
+    ],
+    [
+      '123',
+      (x: string) => Number(x) >= 1,
+    ],
+    [
+      '123',
+      (x: string) => Number(x) < 4,
+    ],
+    [
+      'a',
+      (x: string) => x === 'a',
+    ],
+    [
+      'ABC',
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      'abc',
+      (x: string) => x.toLowerCase() === x,
+    ],
+  ];
+}
+
+function dataProviderForSetsFalse(): Array<[Set<any>, (item: any) => boolean]> {
+  return [
+    [
+      new Set([]),
+      () => true,
+    ],
+    [
+      new Set([]),
+      () => false,
+    ],
+    [
+      new Set([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      new Set([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      new Set([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      new Set(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      new Set(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      new Set(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      new Set(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      new Set([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForMapsFalse(): Array<[Map<any, any>, (item: any) => boolean]> {
+  return [
+    [
+      createMapFixture([]),
+      () => true,
+    ],
+    [
+      createMapFixture([]),
+      () => false,
+    ],
+    [
+      createMapFixture([1]),
+      (x: [unknown, number]) => x[1] === 1,
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (x: [unknown, number]) => x[1] >= 1,
+    ],
+    [
+      createMapFixture([1, 2, 3]),
+      (x: [unknown, number]) => x[1] < 4,
+    ],
+    [
+      createMapFixture(['a']),
+      (x: [unknown, string]) => x[1] === 'a',
+    ],
+    [
+      createMapFixture(['A', 'B', 'C']),
+      (x: [unknown, string]) => x[1].toUpperCase() === x[1],
+    ],
+    [
+      createMapFixture(['a', 'b', 'c']),
+      (x: [unknown, string]) => x[1].toLowerCase() === x[1],
+    ],
+    [
+      createMapFixture(['OS', 'PHP', 'COBOL']),
+      (x: [unknown, string]) => x[1].toUpperCase() === x[1],
+    ],
+    [
+      createMapFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: [unknown, Array<unknown>]) => x[1].length === 3,
+    ],
+  ];
+}
+
+function dataProviderForAsyncGeneratorsFalse(): Array<[AsyncGenerator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createAsyncGeneratorFixture([]),
+      () => true,
+    ],
+    [
+      createAsyncGeneratorFixture([]),
+      () => false,
+    ],
+    [
+      createAsyncGeneratorFixture([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      createAsyncGeneratorFixture([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      createAsyncGeneratorFixture([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      createAsyncGeneratorFixture(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      createAsyncGeneratorFixture(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncGeneratorFixture(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createAsyncGeneratorFixture(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncGeneratorFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForAsyncIterablesFalse(): Array<[AsyncIterable<any>, (item: any) => boolean]> {
+  return [
+    [
+      createAsyncIterableFixture([]),
+      () => true,
+    ],
+    [
+      createAsyncIterableFixture([]),
+      () => false,
+    ],
+    [
+      createAsyncIterableFixture([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      createAsyncIterableFixture([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      createAsyncIterableFixture([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      createAsyncIterableFixture(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      createAsyncIterableFixture(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIterableFixture(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createAsyncIterableFixture(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIterableFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}
+
+function dataProviderForAsyncIteratorsFalse(): Array<[AsyncIterator<any>, (item: any) => boolean]> {
+  return [
+    [
+      createAsyncIteratorFixture([]),
+      () => true,
+    ],
+    [
+      createAsyncIteratorFixture([]),
+      () => false,
+    ],
+    [
+      createAsyncIteratorFixture([1]),
+      (x: number) => x === 1,
+    ],
+    [
+      createAsyncIteratorFixture([1, 2, 3]),
+      (x: number) => x >= 1,
+    ],
+    [
+      createAsyncIteratorFixture([1, 2, 3]),
+      (x: number) => x < 4,
+    ],
+    [
+      createAsyncIteratorFixture(['a']),
+      (x: string) => x === 'a',
+    ],
+    [
+      createAsyncIteratorFixture(['A', 'B', 'C']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIteratorFixture(['a', 'b', 'c']),
+      (x: string) => x.toLowerCase() === x,
+    ],
+    [
+      createAsyncIteratorFixture(['OS', 'PHP', 'COBOL']),
+      (x: string) => x.toUpperCase() === x,
+    ],
+    [
+      createAsyncIteratorFixture([[1, 2, 3], ['a', 'b', 'c'], [1.1, 2.2, 3.3]]),
+      (x: Array<unknown>) => x.length === 3,
+    ],
+  ];
+}

--- a/tests/transform/distribute.test.ts
+++ b/tests/transform/distribute.test.ts
@@ -5,104 +5,136 @@ import {
   createGeneratorFixture,
   createIterableFixture,
   createIteratorFixture,
-} from "../fixture";
-import { AsyncStream, InvalidArgumentError, Stream, transform } from "../../src";
+  // @ts-ignore
+} from '../fixture';
+import { InvalidArgumentError, transform } from '../../src';
 
-describe.each(syncDataProvider())(
-  "transform.distribute",
+describe.each(dataProvider())(
+  'transform.distribute',
   (input, n, expected) => {
     it(`distributes input into ${n} groups`, () => {
-      expect(Array.from(transform.distribute(input, n))).toEqual(expected);
+      const result = Array.from(transform.distribute(input, n));
+
+      expect(result).toEqual(expected);
     });
   }
 );
 
-describe.each([...syncDataProvider(), ...asyncDataProvider()])(
-  "transform.distributeAsync",
+describe.each(dataProviderAsync())(
+  'transform.distributeAsync',
   (input, n, expected) => {
     it(`distributes input into ${n} groups`, async () => {
-      expect(
-        await transform.toArrayAsync(transform.distributeAsync(input, n))
-      ).toEqual(expected);
+      const result: any[] = [];
+      for await (const group of transform.distributeAsync(input, n)) {
+        result.push(group);
+      }
+
+      expect(result).toEqual(expected);
     });
   }
 );
 
-describe("stream distribute methods", () => {
-  it("distributes a Stream", () => {
-    expect(Stream.of([1, 2, 3, 4, 5]).distribute(3).toArray()).toEqual([
-      [1, 4],
-      [2, 5],
-      [3],
-    ]);
-  });
-
-  it("distributes an AsyncStream", async () => {
-    expect(
-      await AsyncStream.of([1, 2, 3, 4, 5]).distribute(3).toArray()
-    ).toEqual([[1, 4], [2, 5], [3]]);
-  });
-});
-
-it.each([0, -1, 1.5, NaN, Infinity, "2", true])(
-  "rejects invalid group count %s",
-  (n) => {
-    expect(() =>
-      Array.from(transform.distribute([], n as number))
-    ).toThrow(InvalidArgumentError);
+describe.each(dataProviderForError())(
+  'transform.distribute Error Test',
+  (input, n) => {
+    it(`throws error when distributing into ${n} groups`, () => {
+      expect(() => {
+        Array.from(transform.distribute(input, n));
+      }).toThrow(InvalidArgumentError);
+    });
   }
 );
 
-it.each([0, -1, 1.5, NaN, Infinity, "2", true])(
-  "rejects invalid async group count %s",
-  async (n) => {
-    await expect(
-      transform.toArrayAsync(transform.distributeAsync([], n as number))
-    ).rejects.toThrow(InvalidArgumentError);
+describe.each(dataProviderForAsyncError())(
+  'transform.distributeAsync Error Test',
+  (input, n) => {
+    it(`throws error when distributing into ${n} groups`, async () => {
+      await expect(async () => {
+        for await (const _ of transform.distributeAsync(input as any, n as any)) {
+          // noop
+        }
+      }).rejects.toThrow(InvalidArgumentError);
+    });
   }
 );
 
-function syncDataProvider(): Array<
-  [Iterable<unknown> | Iterator<unknown>, number, Array<Array<unknown>>]
-> {
+function dataProvider(): Array<[Iterable<any> | Iterator<any>, number, Array<any[]>]> {
   return [
+    // Arrays
     [[], 2, [[], []]],
     [[1, 2, 3, 4], 2, [[1, 3], [2, 4]]],
     [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
     [[1, 2], 4, [[1], [2], [], []]],
-    ["abcde", 2, [["a", "c", "e"], ["b", "d"]]],
+
+    // Strings
+    ['abcde', 2, [['a', 'c', 'e'], ['b', 'd']]],
+
+    // Sets
     [new Set([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
-    [
-      new Map([
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
-      ]),
-      2,
-      [
-        [
-          ["a", 1],
-          ["c", 3],
-        ],
-        [["b", 2]],
-      ],
-    ],
+
+    // Maps
+    [new Map([['a', 1], ['b', 2], ['c', 3]]), 2,
+      [[['a', 1], ['c', 3]], [['b', 2]]]],
+
+    // Generators
     [createGeneratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Iterables
     [createIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Iterators
     [createIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
   ];
 }
 
-function asyncDataProvider(): Array<
-  [
-    AsyncIterable<unknown> | AsyncIterator<unknown> | Iterable<unknown> | Iterator<unknown>,
-    number,
-    Array<Array<unknown>>
-  ]
-> {
+function dataProviderAsync(): Array<[AsyncIterable<any> | AsyncIterator<any> | Iterable<any> | Iterator<any>, number, Array<any[]>]> {
   return [
+    // Async Generators
     [createAsyncGeneratorFixture([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+
+    // Async Iterables
     [createAsyncIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+
+    // Async Iterators
     [createAsyncIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+  ];
+}
+
+function dataProviderForError(): Array<[any, any]> {
+  return [
+    // Invalid 'n'
+    [[], 0],
+    [[], -1],
+    [[1, 2, 3], 0],
+    [[1, 2, 3], -5],
+    [[1, 2, 3], NaN],
+    [[1, 2, 3], Infinity],
+    [[1, 2, 3], -Infinity],
+    [[1, 2, 3], 1.5],
+    [[1, 2, 3], "2"],
+    [[1, 2, 3], true],
+  ];
+}
+
+function dataProviderForAsyncError(): Array<[any, any]> {
+  return [
+    // Invalid 'n'
+    [[], 0],
+    [[], -1],
+    [[1, 2, 3], 0],
+    [[1, 2, 3], -5],
+    [[1, 2, 3], NaN],
+    [[1, 2, 3], Infinity],
+    [[1, 2, 3], -Infinity],
+    [[1, 2, 3], 1.5],
+    [[1, 2, 3], "2"],
+    [[1, 2, 3], true],
+
+    // Non-iterable input
+    [1, 2],
+    [true, 2],
+    [null, 2],
+    [undefined, 2],
+    [NaN, 2],
   ];
 }

--- a/tests/transform/distribute.test.ts
+++ b/tests/transform/distribute.test.ts
@@ -1,0 +1,110 @@
+import {
+  createAsyncGeneratorFixture,
+  createAsyncIterableFixture,
+  createAsyncIteratorFixture,
+  createGeneratorFixture,
+  createIterableFixture,
+  createIteratorFixture,
+} from "../fixture";
+import { AsyncStream, InvalidArgumentError, Stream, transform } from "../../src";
+
+describe.each(syncDataProvider())(
+  "transform.distribute",
+  (input, n, expected) => {
+    it(`distributes input into ${n} groups`, () => {
+      expect(Array.from(transform.distribute(input, n))).toEqual(expected);
+    });
+  }
+);
+
+describe.each(asyncDataProvider())(
+  "transform.distributeAsync",
+  (input, n, expected) => {
+    it(`distributes input into ${n} groups`, async () => {
+      expect(
+        await transform.toArrayAsync(transform.distributeAsync(input, n))
+      ).toEqual(expected);
+    });
+  }
+);
+
+describe("stream distribute methods", () => {
+  it("distributes a Stream", () => {
+    expect(Stream.of([1, 2, 3, 4, 5]).distribute(3).toArray()).toEqual([
+      [1, 4],
+      [2, 5],
+      [3],
+    ]);
+  });
+
+  it("distributes an AsyncStream", async () => {
+    expect(
+      await AsyncStream.of([1, 2, 3, 4, 5]).distribute(3).toArray()
+    ).toEqual([[1, 4], [2, 5], [3]]);
+  });
+});
+
+it.each([0, -1, 1.5, NaN, Infinity, "2", true])(
+  "rejects invalid group count %s",
+  (n) => {
+    expect(() =>
+      Array.from(transform.distribute([], n as number))
+    ).toThrow(InvalidArgumentError);
+  }
+);
+
+it.each([0, -1, 1.5, NaN, Infinity, "2", true])(
+  "rejects invalid async group count %s",
+  async (n) => {
+    await expect(
+      transform.toArrayAsync(transform.distributeAsync([], n as number))
+    ).rejects.toThrow(InvalidArgumentError);
+  }
+);
+
+function syncDataProvider(): Array<
+  [Iterable<unknown> | Iterator<unknown>, number, Array<Array<unknown>>]
+> {
+  return [
+    [[], 2, [[], []]],
+    [[1, 2, 3, 4], 2, [[1, 3], [2, 4]]],
+    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
+    [[1, 2], 4, [[1], [2], [], []]],
+    ["abcde", 2, [["a", "c", "e"], ["b", "d"]]],
+    [new Set([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+    [
+      new Map([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]),
+      2,
+      [
+        [
+          ["a", 1],
+          ["c", 3],
+        ],
+        [["b", 2]],
+      ],
+    ],
+    [createGeneratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+    [createIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+    [createIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+  ];
+}
+
+function asyncDataProvider(): Array<
+  [
+    AsyncIterable<unknown> | AsyncIterator<unknown> | Iterable<unknown> | Iterator<unknown>,
+    number,
+    Array<Array<unknown>>
+  ]
+> {
+  return [
+    [[], 2, [[], []]],
+    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
+    [createAsyncGeneratorFixture([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
+    [createAsyncIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+    [createAsyncIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],
+  ];
+}

--- a/tests/transform/distribute.test.ts
+++ b/tests/transform/distribute.test.ts
@@ -17,7 +17,7 @@ describe.each(syncDataProvider())(
   }
 );
 
-describe.each(asyncDataProvider())(
+describe.each([...syncDataProvider(), ...asyncDataProvider()])(
   "transform.distributeAsync",
   (input, n, expected) => {
     it(`distributes input into ${n} groups`, async () => {
@@ -101,8 +101,6 @@ function asyncDataProvider(): Array<
   ]
 > {
   return [
-    [[], 2, [[], []]],
-    [[1, 2, 3, 4, 5], 3, [[1, 4], [2, 5], [3]]],
     [createAsyncGeneratorFixture([1, 2, 3, 4]), 2, [[1, 3], [2, 4]]],
     [createAsyncIterableFixture([1, 2, 3]), 2, [[1, 3], [2]]],
     [createAsyncIteratorFixture([1, 2, 3]), 2, [[1, 3], [2]]],


### PR DESCRIPTION
### New features
* summary
  * `isPartitioned()`
  * `isPartitionedAsync()`
  * `notAllMatch()`
  * `notAllMatchAsync()`
* transform
  * `distribute()`
  * `distributeAsync()`
* Stream
  * `isPartitioned()`
  * `notAllMatch()`
  * `distribute()`
* AsyncStream
  * `isPartitioned()`
  * `notAllMatch()`
  * `distribute()`

### Improvements
* `reduce.toAverage()` / `toAverageAsync()` optimized (removed `toValue` overhead)
* `reduce.toMax()` / `toMaxAsync()` optimized (single-pass, cached comparison)
* `reduce.toMin()` / `toMinAsync()` optimized (single-pass, cached comparison)
* `reduce.toMinMax()` / `toMinMaxAsync()` optimized (single-pass, cached comparison)
* `reduce.toSum()` / `toSumAsync()` optimized (removed `toValue` overhead)
* `reduce.toProduct()` / `toProductAsync()` optimized (removed `toValue` overhead)
* `reduce.toCount()` / `toCountAsync()` optimized (removed `toValue` overhead)
* `combinatorics.cartesianProduct()` / `cartesianProductAsync()` optimized (lazy generation, memory-efficient)
* `transform.toMap()` / `toMapAsync()` optimized (direct Map constructor)
* `transform.toSet()` optimized (direct Set constructor)
* `single.flatten()` / `flattenAsync()` optimized (Map check cached)

### Typing fixes
* `peek()` callback parameter type fixed from `unknown` to `T` in Stream and AsyncStream
